### PR TITLE
Increase consistency of references to AutoRotation Plugins

### DIFF
--- a/AutoDuty/AutoDuty.json
+++ b/AutoDuty/AutoDuty.json
@@ -2,7 +2,7 @@
   "Author": "Herculezz",
   "Name": "AutoDuty",
   "Punchline": "AutoDuty",
-  "Description": "A plugin to run dungeons for you with Trust, Duty Support, Squadrons, Variants, and Regular, Requires BossMod, vnavmesh and a Rotation Plugin (BossMod AutoRotation or RotationSolverReborn)",
+  "Description": "A plugin to run dungeons for you with Trust, Duty Support, Squadrons, Variants, and Regular, Requires BossMod, vnavmesh and a Rotation Plugin (Wrath Combo, BossMod AutoRotation, or RotationSolverReborn)",
   "InternalName": "AutoDuty",
   "DalamudApiLevel": "11",
   "RepoUrl": "https://github.com/ffxivcode/AutoDuty",

--- a/AutoDuty/IPC/IPCSubscriber.cs
+++ b/AutoDuty/IPC/IPCSubscriber.cs
@@ -309,8 +309,7 @@ namespace AutoDuty.IPC
         private static EzIPCDisposalToken[] _disposalTokens = EzIPC.Init(typeof(Wrath_IPCSubscriber), "WrathCombo", SafeWrapper.IPCException);
 
         /// <summary>
-        ///     Register your plugin for control of Wrath Combo.<br />
-        ///     Guid? RegisterForLease(string internalPluginName, string pluginName, Action CancellationReason, string? leaseCancelledCallback = null)
+        ///     Register your plugin for control of Wrath Combo.
         /// </summary>
         /// <param name="internalPluginName">
         ///     The internal name of your plugin.<br />
@@ -349,9 +348,8 @@ namespace AutoDuty.IPC
         ///     </list>
         /// </returns>
         /// <remarks>
-        ///     Each lease is limited to controlling <c>40</c> configurations.
+        ///     Each lease is limited to controlling <c>60</c> configurations.
         /// </remarks>
-        /// <seealso cref="Leasing.MaxLeaseConfigurations" />
         [EzIPC] private static readonly Func<string, string, Action<CancellationReason, string>?, Guid?> RegisterForLease;
 
         /// <summary>
@@ -369,7 +367,7 @@ namespace AutoDuty.IPC
         /// </summary>
         /// <param name="lease">Your lease ID from <see cref="RegisterForLease" /></param>
         /// <param name="enabled">
-        ///     Optionally whether to enabled Auto-Rotation.<br />
+        ///     Optionally whether to enable Auto-Rotation.<br />
         ///     Only used to disable Auto-Rotation, as enabling it is the default.
         /// </param>
         /// <seealso cref="GetAutoRotationState" />
@@ -396,8 +394,12 @@ namespace AutoDuty.IPC
         ///     This will try to use the user's existing settings, only enabling default
         ///     states for jobs that are not configured.
         /// </summary>
-        /// <value>+6 <c>set</c></value>
+        /// <value>
+        ///     +2 <c>set</c><br />
+        ///     (can be up to 38 for non-simple jobs, the highest being healers)
+        /// </value>
         /// <param name="lease">Your lease ID from <see cref="RegisterForLease" /></param>
+        /// <remarks>This can take a little bit to finish.</remarks>
         [EzIPC] private static readonly Action<Guid> SetCurrentJobAutoRotationReady;
 
         /// <summary>
@@ -424,9 +426,7 @@ namespace AutoDuty.IPC
         /// <param name="option">
         ///     The Auto-Rotation Configuration option you want to set.<br />
         ///     This is a subset of the Auto-Rotation options, flattened into a single
-        ///     enum.<br />
-        ///     All valid options can be parsed from an int, or
-        ///     <see cref="AutoRotationConfigOption" />.
+        ///     enum.
         /// </param>
         /// <param name="value">
         ///     The value you want to set the option to.<br />

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -484,14 +484,14 @@ public static class ConfigTab
 
             if (ImGui.Checkbox("Auto Manage Rotation Plugin State", ref Configuration.AutoManageRotationPluginState))
                 Configuration.Save();
-            ImGuiComponents.HelpMarker("Autoduty will enable the Rotation Plugin at the start of each duty\n*Only if using Wrath, Rotation Solver or BossMod AutoRotation\n**AutoDuty will try to use them in that order");
+            ImGuiComponents.HelpMarker("Autoduty will enable the Rotation Plugin at the start of each duty\n*Only if using Wrath Combo, Rotation Solver or BossMod AutoRotation\n**AutoDuty will try to use them in that order");
 
             if (Configuration.AutoManageRotationPluginState)
             {
                 if (Wrath_IPCSubscriber.IsEnabled)
                 {
                     ImGui.PushStyleVar(ImGuiStyleVar.SelectableTextAlign, new Vector2(0.5f, 0.5f));
-                    var wrathSettingHeader = ImGui.Selectable("> Wrath Config Options <", wrathSettingHeaderSelected, ImGuiSelectableFlags.DontClosePopups);
+                    var wrathSettingHeader = ImGui.Selectable("> Wrath Combo Config Options <", wrathSettingHeaderSelected, ImGuiSelectableFlags.DontClosePopups);
                     ImGui.PopStyleVar();
                     if (ImGui.IsItemHovered())
                         ImGui.SetMouseCursor(ImGuiMouseCursor.Hand);
@@ -508,7 +508,7 @@ public static class ConfigTab
                             Configuration.Wrath_AutoSetupJobs = wrath_AutoSetupJobs;
                             Configuration.Save();
                         }
-                        ImGuiComponents.HelpMarker("If this is not enabled and a job is not setup in wrath, AD will instead use RSR or bm AutoRotation");
+                        ImGuiComponents.HelpMarker("If this is not enabled and a job is not setup in Wrath Combo, AD will instead use RSR or bm AutoRotation");
 
                         ImGui.Unindent();
                         ImGui.Separator();
@@ -727,7 +727,7 @@ public static class ConfigTab
             {
                 if (ImGui.Checkbox("Using Alternative Rotation Plugin", ref Configuration.UsingAlternativeRotationPlugin))
                     Configuration.Save();
-                ImGuiComponents.HelpMarker("You are deciding to use a plugin other than Wrath, Rotation Solver or BossMod AutoRotation.");
+                ImGuiComponents.HelpMarker("You are deciding to use a plugin other than Wrath Combo, Rotation Solver or BossMod AutoRotation.");
 
                 if (ImGui.Checkbox("Using Alternative Movement Plugin", ref Configuration.UsingAlternativeMovementPlugin))
                     Configuration.Save();

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -184,8 +184,8 @@ namespace AutoDuty.Windows
                                 ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires VNavmesh plugin to be Installed and Loaded\nPlease add 3rd party repo:\nhttps://puni.sh/api/repository/veyn");
                             if (!BossMod_IPCSubscriber.IsEnabled && !Plugin.Configuration.UsingAlternativeBossPlugin)
                                 ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires BossMod plugin to be Installed and Loaded\nPlease add 3rd party repo:\nhttps://puni.sh/api/repository/veyn");
-                            if (!ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled && !BossMod_IPCSubscriber.IsEnabled && !Plugin.Configuration.UsingAlternativeRotationPlugin)
-                                ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires a Rotation plugin to be Installed and Loaded (Either Rotation Solver Reborn or BossMod AutoRotation)");
+                            if (!Wrath_IPCSubscriber.IsEnabled && !ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled && !BossMod_IPCSubscriber.IsEnabled && !Plugin.Configuration.UsingAlternativeRotationPlugin)
+                                ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires a Rotation plugin to be Installed and Loaded (Either Wrath Combo, Rotation Solver Reborn, or BossMod AutoRotation)");
                         }
                         ImGui.EndListBox();
                     }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Settings can be accessed via the Plugin Installer or using the chat command `/ad
 Additionally, the following plugins are required. Right-click the name of the plugin and copy the URL to use it to add to your repositories in-game.
 
 - [vnavmesh](https://puni.sh/api/repository/veyn): Automatic navigation with waypoints
-- [Rotation Solver Reborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json): Automatic rotation execution, all jobs supported
+- [Wrath Combo](https://github.com/PunishXIV/WrathCombo) or [Rotation Solver Reborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json): Automatic rotation execution, all jobs supported
 - [Veyn's Boss Mod](https://puni.sh/api/repository/veyn) or [BossmodReborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json): Automatic fight execution for bosses
 
 ## Optional Plugins
@@ -66,6 +66,8 @@ When you've found a bug or think you have an issue with the plugin, please ask i
 
 Best practice is to not say "I died in this dungeon and I don't know why." Please make sure to include as much detail as possible. What boss were you on? Did you get stuck in a specific spot?
 
-For support with Veyn's Boss Mod and vnavmesh, please ask in [this channel](https://discord.com/channels/1001823907193552978/1191076246860349450) in the [Puni.sh Discord server](https://discord.gg/punishxiv). For support with BossModReborn and Rotation Solver Reborn, please ask in the [Combat Reborn Discord server](https://discord.gg/p54TZMPnC9).
+For support with Veyn's Boss Mod and vnavmesh, please ask in [this channel](https://discord.com/channels/1001823907193552978/1191076246860349450) in the [Puni.sh Discord server](https://discord.gg/punishxiv),
+or support for Wrath Combo in [this channel](https://discord.com/channels/1001823907193552978/1271175781569003590) in the Puni.sh server. For support with BossModReborn and 
+Rotation Solver Reborn, please ask in the [Combat Reborn Discord server](https://discord.gg/p54TZMPnC9).
 
 Lastly, feel free to create issues with feature requests and bug reports.


### PR DESCRIPTION
Namely, adding Wrath Combo to places where other Auto-Rotation plugins were referenced, and making references to it consistent.

Also, this updates the Wrath Combo IPC method comments to be equivalent to what was marked Ready-to-Review in the IPC creation PR for Wrath Combo.