### PR TITLE
Tweaks to the VBM ar preset

### DIFF
--- a/AutoDuty/Resources/AutoDuty.json
+++ b/AutoDuty/Resources/AutoDuty.json
@@ -7,12 +7,18 @@
         "Option": "Aggressive"
       },
       {
-        "Track": "Everything",
-        "Option": "Enabled"
-      },
-      {
         "Track": "Retarget",
         "Option": "Always"
+      }
+    ],
+    "BossMod.Autorotation.xan.BLU": [
+      {
+        "Track": "Targeting",
+        "Option": "Auto"
+      },
+      {
+        "Track": "AOE",
+        "Option": "AOE"
       }
     ],
     "BossMod.Autorotation.xan.BLM": [


### PR DESCRIPTION
add blu module and disable target everything

Without target everything set it behaves similarly to how it did before the targeting overhaul. packs have to be face pulled but it also doesnt target things miles away breaking the path.

Not sure if this is better overall in every dungeon, but it seems to work better in prae and is more similar to how it worked previously.

xan blu module seems to work fairly well with the right spells set and initial comparison seems to be about a minute quicker too, so the rotation is good enough to be stronger than mch by a lot.