### PR TITLE
Adding delays before the scales puzzle extend delay before the door

### DIFF
--- a/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 10 - Middle.json
+++ b/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 10 - Middle.json
@@ -392,6 +392,20 @@
     },
     {
       "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "10000"
+      ],
+      "Conditions": [],
+      "Note": "RP"
+    },
+    {
+      "Tag": "None",
       "Name": "Interactable",
       "Position": {
         "X": 0.0,
@@ -531,7 +545,12 @@
   ],
   "Meta": {
     "CreatedAt": 285,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 286,
+        "Change": "Add delay before scales puzzle"
+      }
+    ],
     "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 11 - Middle.json
+++ b/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 11 - Middle.json
@@ -392,6 +392,20 @@
     },
     {
       "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "10000"
+      ],
+      "Conditions": [],
+      "Note": "RP"
+    },
+    {
+      "Tag": "None",
       "Name": "Interactable",
       "Position": {
         "X": 0.0,
@@ -531,7 +545,12 @@
   ],
   "Meta": {
     "CreatedAt": 285,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 286,
+        "Change": "Add delay before scales puzzle"
+      }
+    ],
     "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 5 - Right.json
+++ b/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 5 - Right.json
@@ -308,7 +308,7 @@
         "Z": 0.0
       },
       "Arguments": [
-        "10000"
+        "20000"
       ],
       "Conditions": [],
       "Note": "RP"
@@ -372,7 +372,12 @@
   ],
   "Meta": {
     "CreatedAt": 285,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 286,
+        "Change": "Increase door delay because it felt close..."
+      }
+    ],
     "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 8 - Middle.json
+++ b/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 8 - Middle.json
@@ -392,6 +392,20 @@
     },
     {
       "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "10000"
+      ],
+      "Conditions": [],
+      "Note": "RP"
+    },
+    {
+      "Tag": "None",
       "Name": "Interactable",
       "Position": {
         "X": 0.0,
@@ -517,7 +531,12 @@
   ],
   "Meta": {
     "CreatedAt": 285,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 286,
+        "Change": "Add delay before scales puzzle"
+      }
+    ],
     "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 9 - Middle.json
+++ b/AutoDuty/Paths/(1069) The Sil'dihn Subterrane - Exit 9 - Middle.json
@@ -392,6 +392,20 @@
     },
     {
       "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "10000"
+      ],
+      "Conditions": [],
+      "Note": "RP"
+    },
+    {
+      "Tag": "None",
       "Name": "Interactable",
       "Position": {
         "X": 0.0,
@@ -517,7 +531,12 @@
   ],
   "Meta": {
     "CreatedAt": 285,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 286,
+        "Change": "Add delay before scales puzzle"
+      }
+    ],
     "Notes": []
   }
 }


### PR DESCRIPTION
This fixes some borderline delays that broke while running an alt through to verify the path numbers.