### PR TITLE
Fix: Main tab information not correctly when entering another dungeon after the first time.

### DIFF
--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -142,7 +142,7 @@ namespace AutoDuty.Windows
 
             if (InDungeon)
             {
-                if (Plugin.CurrentTerritoryContent == null)
+                if (Plugin.CurrentTerritoryContent == null || Plugin.CurrentTerritoryContent.TerritoryType != Svc.ClientState.TerritoryType)
                 {
                     Plugin.LoadPath();
                 }


### PR DESCRIPTION
Fix: Main tab information not correctly when entering another dungeon  after the first time.