### PR TITLE
Updates for Sastasha, TamTara, Copperbell Mines, TotoRak & Halatali; New Path for Final Coil T4; Adjusted Eyes of the Creator

### DIFF
--- a/AutoDuty/Paths/(1036) Sastasha.json
+++ b/AutoDuty/Paths/(1036) Sastasha.json
@@ -2,16 +2,71 @@
   "Actions": [
     {
       "Tag": "None",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "IsReady"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
       "Name": "DutySpecificCode",
       "Position": {
-        "X": 347.75,
-        "Y": 44.14,
-        "Z": -223.21
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
         "1"
       ],
+      "Conditions": [],
       "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "Rotation",
+      "Position": {
+        "X": 223.55579,
+        "Y": 40.314785,
+        "Z": -146.92798
+      },
+      "Arguments": [
+        "OFF"
+      ],
+      "Conditions": [],
+      "Note": "To avoid aggroing clams, which may not die and keep you in combat."
     },
     {
       "Tag": "Treasure",
@@ -24,19 +79,89 @@
       "Arguments": [
         ""
       ],
+      "Conditions": [],
       "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "Rotation",
+      "Position": {
+        "X": 75.09057,
+        "Y": 29.933828,
+        "Z": -44.197563
+      },
+      "Arguments": [
+        "ON"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "5000"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "Rotation",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "OFF"
+      ],
+      "Conditions": [],
+      "Note": "To avoid the small chance of attacking a clam."
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 1 -->"
     },
     {
       "Tag": "None",
       "Name": "DutySpecificCode",
       "Position": {
-        "X": 90.26,
-        "Y": 27.2,
-        "Z": -56.04
+        "X": 80.45049,
+        "Y": 29.748713,
+        "Z": -47.99161
       },
       "Arguments": [
         "2"
       ],
+      "Conditions": [],
       "Note": ""
     },
     {
@@ -50,6 +175,33 @@
       "Arguments": [
         "3"
       ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "Rotation",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ON"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
       "Note": ""
     },
     {
@@ -63,7 +215,22 @@
       "Arguments": [
         ""
       ],
-      "Note": ""
+      "Conditions": [],
+      "Note": "Chopper"
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 64.55058,
+        "Y": 32.604614,
+        "Z": -33.108906
+      },
+      "Arguments": [
+        "ObjectData;2000216; IsTargetable;FALSE & ModifyIndex;+2"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Switch is not targetable / the door is open."
     },
     {
       "Tag": "None",
@@ -76,7 +243,46 @@
       "Arguments": [
         "2000216"
       ],
+      "Conditions": [],
       "Note": "Inconspicuous Switch"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 2 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
     },
     {
       "Tag": "None",
@@ -87,22 +293,24 @@
         "Z": 56.34
       },
       "Arguments": [
-        "<-31,24,63>"
+        "<-30.66, 23.76, 62.21>"
       ],
-      "Note": ""
+      "Conditions": [],
+      "Note": "Captain Madison"
     },
     {
-      "Tag": "None",
-      "Name": "Interactable",
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
       "Position": {
-        "X": -91.82,
-        "Y": 13.84,
-        "Z": 145.88
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
-        "2000250"
+        "FALSE"
       ],
-      "Note": "Captain's Quarters Key"
+      "Conditions": [],
+      "Note": ""
     },
     {
       "Tag": "Comment",
@@ -112,62 +320,107 @@
         "Y": 0.0,
         "Z": 0.0
       },
-      "Arguments": [
-        ""
-      ],
-      "Note": "<-- Below line is a temporary bandaid until Issue #409 is implemented -->"
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
     },
     {
       "Tag": "None",
       "Name": "ConditionAction",
       "Position": {
-        "X": -95.1,
-        "Y": 19.9,
-        "Z": 171.1
+        "X": -90.88243,
+        "Y": 13.84802,
+        "Z": 141.75797
       },
       "Arguments": [
-        "ItemCount;2000512;<;1&ModifyIndex;7"
+        "ObjectData;2000231; IsTargetable;FALSE & ModifyIndex;+9"
       ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Waverider Gate is already open."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "25"
+      ],
+      "Conditions": [],
       "Note": ""
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": -95.1,
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "2000250"
+      ],
+      "Conditions": [],
+      "Note": "Captain's Quarters Key"
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ItemCount;2000512; <;1 & ModifyIndex;-4"
+      ],
+      "Conditions": [],
+      "Note": "Goes back if you do not have the Key."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -95.085335,
         "Y": 19.9,
-        "Z": 171.1
+        "Z": 171.06482
       },
       "Arguments": [
         "2000227"
       ],
+      "Conditions": [],
       "Note": "Captain's Quarters"
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": -95.15,
-        "Y": 20.01,
-        "Z": 190.03
+        "X": -94.833565,
+        "Y": 20.012,
+        "Z": 192.34413
       },
       "Arguments": [
         "2000255"
       ],
+      "Conditions": [],
       "Note": "Waverider Gate Key"
-    },
-    {
-      "Tag": "Comment",
-      "Name": "<-- Comment -->",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        ""
-      ],
-      "Note": "<-- Below line is a temporary bandaid until Issue #409 is implemented -->"
     },
     {
       "Tag": "None",
@@ -178,34 +431,73 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ItemCount;2000513;<;1&ModifyIndex;11"
+        "ItemCount;2000513; <;1 & ModifyIndex;-1"
       ],
-      "Note": ""
+      "Conditions": [],
+      "Note": "Goes back if you do not have the Key."
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": -129.54,
-        "Y": 16.3,
-        "Z": 156.32
+        "X": -129.77435,
+        "Y": 16.35,
+        "Z": 156.49306
       },
       "Arguments": [
         "2000231"
       ],
+      "Conditions": [],
       "Note": "Waverider Gate"
     },
     {
-      "Tag": "None",
-      "Name": "Boss",
+      "Tag": "Revival",
+      "Name": "Revival",
       "Position": {
-        "X": -183.12,
-        "Y": 6.38,
-        "Z": 244.52
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -199.23349,
+        "Y": 6.3301344,
+        "Z": 265.96167
       },
       "Arguments": [
-        ""
+        "FALSE"
       ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 3 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
       "Note": ""
     },
     {
@@ -219,43 +511,22 @@
       "Arguments": [
         ""
       ],
-      "Note": ""
+      "Conditions": [],
+      "Note": "Denn the Orcatoothed"
     }
   ],
   "Meta": {
-    "CreatedAt": 122,
+    "CreatedAt": 285,
     "Changelog": [
       {
-        "Version": 132,
-        "Change": " "
+        "Version": 297,
+        "Change": ""
       },
       {
-        "Version": 161,
-        "Change": "Converted to new JSON Structure"
-      },
-      {
-        "Version": 163,
-        "Change": "Converted to newer JSON Structure"
-      },
-      {
-        "Version": 164,
-        "Change": "Converted to JSON Structure with Tags"
-      },
-      {
-        "Version": 189,
-        "Change": "Adjusted tags to string values"
-      },
-      {
-        "Version": 230,
-        "Change": "Adjusted boss loot search"
-      },
-      {
-        "Version": 231,
-        "Change": "Re-added last boss step"
+        "Version": 298,
+        "Change": ""
       }
     ],
     "Notes": []
   }
-
 }
-

--- a/AutoDuty/Paths/(1037) The TamTara Deepcroft.json
+++ b/AutoDuty/Paths/(1037) The TamTara Deepcroft.json
@@ -1,273 +1,534 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 4.35,
-        "Y": 41.04,
-        "Z": -77.92
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 2.82,
-        "Y": 29.55,
-        "Z": -17.25
+      "Tag": "Unsynced",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "IsReady"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -8.22,
-        "Y": 30.83,
-        "Z": -16.46
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "FALSE"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "Unsynced",
+      "Name": "MoveTo",
+      "Position": {
+        "X": -47.80308,
+        "Y": 44.37835,
+        "Z": -86.81023
       },
-      "arguments": [
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "MoveTo",
+      "Position": {
+        "X": -43.110474,
+        "Y": 42.11093,
+        "Z": -84.70266
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 1 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -4.3266563,
+        "Y": 29.549915,
+        "Z": -16.60404
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": "Void Soulcounter #1"
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -7.6970167,
+        "Y": 30.82913,
+        "Z": -16.47624
+      },
+      "Arguments": [
+        "ObjectData;2000061; IsTargetable;FALSE & ModifyIndex;+2"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Orb is not targetable / already interacted with."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -7.6970167,
+        "Y": 30.82913,
+        "Z": -16.47624
+      },
+      "Arguments": [
         "2000061"
       ],
-      "note": "Cultist Orb"
+      "Conditions": [],
+      "Note": "Cultist Orb"
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -18.43,
-        "Y": 23.41,
-        "Z": 26.77
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 70.07499,
+        "Y": 23.820414,
+        "Z": 3.4448137
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -23.07,
-        "Y": 24.71,
-        "Z": 20.42
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 8.704077,
+        "Y": 23.482735,
+        "Z": 75.44724
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 2 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -21.644335,
+        "Y": 23.875113,
+        "Z": 22.516497
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Void Soulcounter #2"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -22.79746,
+        "Y": 24.71314,
+        "Z": 20.55435
       },
-      "arguments": [
+      "Arguments": [
+        "ObjectData;2000062; IsTargetable;FALSE & ModifyIndex;+2"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Orb is not targetable / already interacted with."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -22.79746,
+        "Y": 24.71314,
+        "Z": 20.55435
+      },
+      "Arguments": [
         "2000062"
       ],
-      "note": "Cultist Orb"
+      "Conditions": [],
+      "Note": "Cultist Orb"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -177.97,
-        "Y": 13.49,
-        "Z": -5.13
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": -154.19998,
+        "Y": 16.604599,
+        "Z": 106.105545
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -108.48225,
+        "Y": 13.836549,
+        "Z": 16.725882
+      },
+      "Arguments": [
+        "ObjectData;2000060; IsTargetable;FALSE & ModifyIndex;+5"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Barrier is already open."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -174.38287,
+        "Y": 12.627574,
+        "Z": -5.104916
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -177.83923,
+        "Y": 13.487554,
+        "Z": -5.110391
+      },
+      "Arguments": [
         "2000057"
       ],
-      "note": "Cultist Rosary"
+      "Conditions": [],
+      "Note": "Cultist Rosary"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -104.14,
-        "Y": 13.92,
-        "Z": 15.52
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 3 -->"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -104.47461,
+        "Y": 13.92077,
+        "Z": 15.448282
       },
-      "arguments": [
+      "Arguments": [
         "2000060"
       ],
-      "note": "Sealed Barrier"
+      "Conditions": [],
+      "Note": "Sealed Barrier"
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
         "X": -93.34,
         "Y": 13.86,
         "Z": 9.51
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Void Soulcounter #3"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -94.66,
-        "Y": 14.91,
-        "Z": 3.94
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -94.96522,
+        "Y": 14.974234,
+        "Z": 4.1052155
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "ObjectData;2000067; IsTargetable;FALSE & ModifyIndex;+2"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Skips ahead if the Orb is not targetable / already interacted with."
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -94.96522,
+        "Y": 14.974234,
+        "Z": 4.1052155
       },
-      "arguments": [
+      "Arguments": [
         "2000067"
       ],
-      "note": "Cultist Orb"
+      "Conditions": [],
+      "Note": "Cultist Orb"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -89.51,
-        "Y": 14.9,
-        "Z": 13.71
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -89.66112,
+        "Y": 14.961804,
+        "Z": 13.50636
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "ObjectData;2000063; IsTargetable;FALSE & ModifyIndex;+2"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Skips ahead if the Orb is not targetable / already interacted with."
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -89.66112,
+        "Y": 14.961804,
+        "Z": 13.50636
       },
-      "arguments": [
+      "Arguments": [
         "2000063"
       ],
-      "note": "Cultist Orb"
+      "Conditions": [],
+      "Note": "Cultist Orb"
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": -85.41,
+        "Y": 15.046852,
+        "Z": 6.4923916
       },
-      "arguments": [
-        "4000"
+      "Arguments": [
+        "3000"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -51.88,
-        "Y": 14.05,
-        "Z": -12.76
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 4 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -50.046577,
+        "Y": 14.046315,
+        "Z": -13.530736
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -46.75,
-        "Y": 14.05,
-        "Z": -15.12
-      },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Galvanth the Dominator"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 285,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 297,
+        "Change": ""
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
-      },
-      {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
-      },
-      {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 298,
+        "Change": ""
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1038) Copperbell Mines.json
+++ b/AutoDuty/Paths/(1038) Copperbell Mines.json
@@ -1,524 +1,876 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "ForceAttack",
-      "position": {
-        "X": -222.18,
-        "Y": 23.85,
-        "Z": -208.19
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Movement / 動き -->"
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -226.76294,
+        "Y": 23.731129,
+        "Z": -202.62247
       },
-      "arguments": [
-        "3000"
+      "Arguments": [
+        "ObjectData;2000160; IsTargetable;FALSE & ModifyIndex;+5"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Skips ahead if the Door is already open."
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": -222.18,
-        "Y": 23.85,
-        "Z": -208.19
+      "Tag": "None",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
+        "25"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
         "2000159"
       ],
-      "note": "Tiny Key"
+      "Conditions": [],
+      "Note": "Tiny Key"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": -206.3,
-        "Y": 23.47,
-        "Z": -208.46
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
+        "ItemCount;2000441; <;1 & ModifyIndex;-3"
+      ],
+      "Conditions": [],
+      "Note": "Goes back if you do not have the Key."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -206.78925,
+        "Y": 23.484663,
+        "Z": -208.43341
+      },
+      "Arguments": [
         "2000160"
       ],
-      "note": "Sealed Blasting Door"
+      "Conditions": [],
+      "Note": "Sealed Blasting Door"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -184.08,
-        "Y": 24,
-        "Z": -206.39
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -196.15414,
+        "Y": 22.674406,
+        "Z": -207.13116
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "ObjectData;2000162; IsTargetable;FALSE & ModifyIndex;+3"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Skips ahead if the Lift is in the correct position."
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -191.97255,
+        "Y": 22.557713,
+        "Z": -206.4677
       },
-      "arguments": [
-        "2000163"
+      "Arguments": [
+        "2000162"
       ],
-      "note": "Lift Lever"
+      "Conditions": [],
+      "Note": "Clicks the Lever for bringing the Lift back up to the top (if you die before the first boss somehow)."
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -182.83044,
-        "Y": -6.0000143,
-        "Z": -209.94675
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        "false"
-      ],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
-      },
-      "arguments": [
+      "Arguments": [
         "10000"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -178.09,
-        "Y": -6.52,
-        "Z": -208.07
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": -183.85149,
+        "Y": 23.999985,
+        "Z": -206.91066
       },
-      "arguments": [
+      "Arguments": [
+        "2000163"
+      ],
+      "Conditions": [],
+      "Note": "Lift Lever"
+    },
+    {
+      "Tag": "None",
+      "Name": "MoveTo",
+      "Position": {
+        "X": -183.00774,
+        "Y": -6.0000153,
+        "Z": -209.84471
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "10000"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "MoveTo",
+      "Position": {
+        "X": -164.00105,
+        "Y": -7.915082,
+        "Z": -208.1908
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Helps avoid slightly janky pathing when stepping out of the elevator."
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 43.54118,
+        "Y": -9.84726,
+        "Z": -139.50728
+      },
+      "Arguments": [
+        "ObjectData;2001536; IsTargetable;FALSE & ModifyIndex;+6"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Powder Chamber is already blown up."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 51.89,
         "Y": -8.75,
         "Z": -136.52
       },
-      "arguments": [
+      "Arguments": [
         "2000169"
       ],
-      "note": "Firesand"
+      "Conditions": [],
+      "Note": "Firesand"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 52.93,
         "Y": -3.92,
         "Z": -153.77
       },
-      "arguments": [
+      "Arguments": [
         "2000172"
       ],
-      "note": "Firesand"
+      "Conditions": [],
+      "Note": "Firesand"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 43.98,
         "Y": -9.75,
         "Z": -128.93
       },
-      "arguments": [
+      "Arguments": [
         "2001536"
       ],
-      "note": "Powder Chamber"
+      "Conditions": [],
+      "Note": "Powder Chamber"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 42.08,
         "Y": -9.98,
         "Z": -135.22
       },
-      "arguments": [
+      "Arguments": [
         "2000170"
       ],
-      "note": "Blasting Device"
+      "Conditions": [],
+      "Note": "Blasting Device"
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        "2000"
-      ],
-      "note": ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 1 -->"
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 42.98,
-        "Y": -9.92,
-        "Z": -89.63
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 43.097,
+        "Y": -9.924997,
+        "Z": -83.402145
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Kottos"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 42.97,
-        "Y": -9.92,
-        "Z": -69.18
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 43.004242,
+        "Y": -9.924997,
+        "Z": -69.326126
       },
-      "arguments": [
+      "Arguments": [
+        "ObjectData;2000173; IsTargetable;FALSE & ModifyIndex;+5"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Door is already open."
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ItemCount;2000441; >;0 & ModifyIndex;+3"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if you already have the key (ex. picked it up while getting the Boss Chest)."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
         "2000178"
       ],
-      "note": "Tiny Key"
+      "Conditions": [],
+      "Note": "Tiny Key"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ItemCount;2000441; <;1 & ModifyIndex;-3"
+      ],
+      "Conditions": [],
+      "Note": "Goes back if you do not have the Key."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 43.18,
         "Y": -9.92,
         "Z": -58.98
       },
-      "arguments": [
+      "Arguments": [
         "2000173"
       ],
-      "note": "Sealed Blasting Door"
+      "Conditions": [],
+      "Note": "Sealed Blasting Door"
     },
     {
-      "tag": "Treasure",
-      "name": "TreasureCoffer",
-      "position": {
-        "X": 63.44,
-        "Y": -9.92,
-        "Z": -37.99
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "2000179"
+      ],
+      "Conditions": [],
+      "Note": "<-- Movement / 動き -->"
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 63.785522,
+        "Y": -9.873647,
+        "Z": -38.76346
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 56.69,
-        "Y": -8.25,
-        "Z": 5.91
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 57.31621,
+        "Y": -9.924997,
+        "Z": -4.9587045
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "ObjectData;2000174; IsTargetable;FALSE & ModifyIndex;+3"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Skips ahead if the Lift is in the correct position."
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 56.69,
-        "Y": -8.25,
-        "Z": 5.91
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 56.297573,
+        "Y": -9.785133,
+        "Z": -2.439798
       },
-      "arguments": [
-        "2000175"
+      "Arguments": [
+        "2000174"
       ],
-      "note": "Lift Lever"
+      "Conditions": [],
+      "Note": "Clicks the Lever for bringing the Lift back up to the top (if you die before the next boss somehow)."
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 60.041435,
-        "Y": -8.250014,
-        "Z": 7.4902554
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        "false"
-      ],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
-      },
-      "arguments": [
+      "Arguments": [
         "10000"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 58.27,
-        "Y": -38.69,
-        "Z": 11.74
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 56.69,
+        "Y": -8.25,
+        "Z": 5.91
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "2000175"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Lift Lever"
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 92.73,
-        "Y": -42.09,
-        "Z": 39.41
+      "Tag": "None",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 60.025738,
+        "Y": -8.250014,
+        "Z": 6.2503405
       },
-      "arguments": [
-        "2000"
+      "Arguments": [
+        "FALSE"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 91.78,
-        "Y": -42.19,
-        "Z": 41.22
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
+        "10000"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 59.314148,
+        "Y": -38.947536,
+        "Z": 26.892216
+      },
+      "Arguments": [
+        "ObjectData;2001537; IsTargetable;FALSE & ModifyIndex;+8"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Powder Chamber is already blown up."
+    },
+    {
+      "Tag": "None",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 87.68248,
+        "Y": -42.2191,
+        "Z": 40.937878
+      },
+      "Arguments": [
+        "25"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
         "2001531"
       ],
-      "note": "Firesand"
+      "Conditions": [],
+      "Note": "Firesand"
     },
     {
-      "tag": "Treasure",
-      "name": "TreasureCoffer",
-      "position": {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
         "X": 97.55,
         "Y": -41.64,
         "Z": 70.42
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 19.62,
-        "Y": -42.42,
-        "Z": 40.48
+      "Tag": "None",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 27.889702,
+        "Y": -42.33252,
+        "Z": 40.982258
       },
-      "arguments": [
-        "3000"
+      "Arguments": [
+        "25"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 21.7,
-        "Y": -42.69,
-        "Z": 42.35
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
         "2000179"
       ],
-      "note": "Firesand"
+      "Conditions": [],
+      "Note": "Firesand"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 58.89,
         "Y": -38.75,
         "Z": 54.16
       },
-      "arguments": [
+      "Arguments": [
         "2001537"
       ],
-      "note": "Powder Chamber"
+      "Conditions": [],
+      "Note": "Powder Chamber"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 57.48,
         "Y": -38.74,
         "Z": 47.62
       },
-      "arguments": [
+      "Arguments": [
         "2000180"
       ],
-      "note": "Blasting Device"
+      "Conditions": [],
+      "Note": "Blasting Device"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 38.07,
         "Y": -38.69,
         "Z": 60.38
       },
-      "arguments": [
+      "Arguments": [
         "2001532"
       ],
-      "note": "Firesand"
+      "Conditions": [],
+      "Note": "Firesand"
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 27.61,
-        "Y": -38,
-        "Z": 113.91
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss #2 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 28.735514,
+        "Y": -38.0,
+        "Z": 113.01183
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ichorous Ire"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 11.775794,
+        "Y": -38.0,
+        "Z": 112.33469
+      },
+      "Arguments": [
+        "ObjectData;2001538; IsTargetable;FALSE & ModifyIndex;+4"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Powder Chamber is already blown up."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 8.15,
-        "Y": -38,
+        "Y": -38.0,
         "Z": 113.01
       },
-      "arguments": [
+      "Arguments": [
         "2001533"
       ],
-      "note": "Firesand"
+      "Conditions": [],
+      "Note": "Firesand"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 1.84,
         "Y": -37.98,
         "Z": 113.05
       },
-      "arguments": [
+      "Arguments": [
         "2001538"
       ],
-      "note": "Powder Chamber"
+      "Conditions": [],
+      "Note": "Powder Chamber"
     },
     {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
         "X": 4.85,
         "Y": -38.02,
         "Z": 110.96
       },
-      "arguments": [
+      "Arguments": [
         "2001534"
       ],
-      "note": "Blasting Device"
+      "Conditions": [],
+      "Note": "Blasting Device"
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        "4000"
-      ],
-      "note": ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "Treasure",
-      "name": "TreasureCoffer",
-      "position": {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
         "X": -65.28,
-        "Y": -42,
+        "Y": -42.0,
         "Z": 167.21
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -98.82,
-        "Y": -57.88,
-        "Z": 6.8
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": -97.538826,
+        "Y": -38.155354,
+        "Z": 110.03951
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss #3 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -100.3877,
+        "Y": -57.878,
+        "Z": -2.5265365
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": "Gyges the Great"
     }
   ],
-  "meta": {
-    "createdAt": 130,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 285,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 297,
+        "Change": ""
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
-      },
-      {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
-      },
-      {
-        "version": 189,
-        "change": "Adjusted tags to string values"
-      },
-      {
-        "version": 207,
-        "change": "Adjusted elevators"
+        "Version": 298,
+        "Change": ""
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1039) The Thousand Maws of TotoRak.json
+++ b/AutoDuty/Paths/(1039) The Thousand Maws of TotoRak.json
@@ -1,65 +1,362 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -112.77,
-        "Y": -4.13,
-        "Z": 111.97
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -79.82,
-        "Y": -8.13,
-        "Z": -48.07
+      "Tag": "Unsynced",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
-        ""
+      "Arguments": [
+        "IsReady"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 222.07,
-        "Y": -39.29,
-        "Z": -144.12
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -208.96109,
+        "Y": -1.5073593,
+        "Z": 13.701893
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -135.02089,
+        "Y": -5.2052345,
+        "Z": 109.687195
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 1 -->"
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -106.569534,
+        "Y": -4.1569395,
+        "Z": 111.728584
+      },
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Coeurl O' Nine Tails #1"
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": -44.871025,
+        "Y": -4.073307,
+        "Z": 104.78566
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 50.484783,
+        "Y": -16.042198,
+        "Z": 62.27957
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 48.022675,
+        "Y": -17.259413,
+        "Z": 41.36635
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 8.044397,
+        "Y": -11.848574,
+        "Z": -45.251915
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -59.876175,
+        "Y": -8.516265,
+        "Z": -48.039593
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 2 -->"
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -88.34432,
+        "Y": -8.172004,
+        "Z": -49.615223
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": "Coeurl O' Nine Tails #2"
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -57.420975,
+        "Y": -12.791198,
+        "Z": -137.91873
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 54.101856,
+        "Y": -20.022787,
+        "Z": -99.82355
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 121.7126,
+        "Y": -23.328304,
+        "Z": -112.98896
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 3 -->"
+    },
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 227.88693,
+        "Y": -39.29175,
+        "Z": -143.85854
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": "Graffias"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 285,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 297,
+        "Change": ""
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
-      },
-      {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
-      },
-      {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 298,
+        "Change": ""
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1245) Halatali.json
+++ b/AutoDuty/Paths/(1245) Halatali.json
@@ -1,16 +1,126 @@
 {
   "Actions": [
     {
-      "Tag": "None",
-      "Name": "MoveTo",
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
       "Position": {
-        "X": 230.11583,
-        "Y": 9.827038,
-        "Z": -23.979305
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [],
       "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "IsReady"
+      ],
+      "Conditions": [],
       "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 156.9388,
+        "Y": 6.2784195,
+        "Z": -66.165726
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Synced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 128.21317,
+        "Y": -2.7288835,
+        "Z": 27.183329
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": "Has a chance to skip the enemies in the middle of the room."
+    },
+    {
+      "Tag": "Synced",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 124.595665,
+        "Y": -3.7119107,
+        "Z": 66.68335
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Synced",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 92.88048,
+        "Y": -3.5624468,
+        "Z": 82.622375
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Synced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 78.25955,
+        "Y": 1.8193996,
+        "Z": 87.974434
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 1 -->"
     },
     {
       "Tag": "Revival",
@@ -20,56 +130,6 @@
         "Y": 0.0,
         "Z": 0.0
       },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 138.32365,
-        "Y": -1.6419466,
-        "Z": -6.0795965
-      },
-      "Arguments": [],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 122.16758,
-        "Y": -3.0464303,
-        "Z": 35.170464
-      },
-      "Arguments": [],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 91.701355,
-        "Y": -3.6533675,
-        "Z": 82.36648
-      },
-      "Arguments": [],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 17.785288,
-        "Y": 0.9252167,
-        "Z": 99.11807
-      },
       "Arguments": [],
       "Conditions": [],
       "Note": ""
@@ -78,35 +138,23 @@
       "Tag": "None",
       "Name": "Boss",
       "Position": {
-        "X": 30.54,
-        "Y": 0.95,
-        "Z": 129.66
+        "X": 30.076004,
+        "Y": 0.9545418,
+        "Z": 125.03961
       },
       "Arguments": [
         ""
       ],
       "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 36.138577,
-        "Y": 0.9545418,
-        "Z": 127.80088
-      },
-      "Arguments": [],
-      "Conditions": [],
-      "Note": ""
+      "Note": "Firemane"
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": 32.06,
-        "Y": 0.95,
-        "Z": 129.77
+        "X": 32.866,
+        "Y": 0.9545418,
+        "Z": 130.9583
       },
       "Arguments": [
         "2001619"
@@ -129,6 +177,18 @@
       "Note": ""
     },
     {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
       "Tag": "None",
       "Name": "WaitFor",
       "Position": {
@@ -143,12 +203,40 @@
       "Note": ""
     },
     {
-      "Tag": "None",
-      "Name": "Interactable",
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
       "Position": {
         "X": 0.0,
         "Y": 0.0,
         "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 84.940125,
+        "Y": -9.467616,
+        "Z": -90.177826
+      },
+      "Arguments": [
+        "ObjectData;2001624; IsTargetable;FALSE & ModifyIndex;+3"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Winch is not targetable / already interacted with."
+    },
+    {
+      "Tag": "None",
+      "Name": "Interactable",
+      "Position": {
+        "X": 74.735535,
+        "Y": -11.165159,
+        "Z": -105.90789
       },
       "Arguments": [
         "2001624"
@@ -157,24 +245,40 @@
       "Note": "Chain Winch"
     },
     {
-      "Tag": "None",
-      "Name": "MoveTo",
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
       "Position": {
-        "X": 74.644196,
-        "Y": -10.853093,
-        "Z": -108.25956
+        "X": 75.234436,
+        "Y": -11.03907,
+        "Z": -106.76251
       },
-      "Arguments": [],
+      "Arguments": [
+        ""
+      ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Chance to spawn after using a Winch."
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": 61.046783,
+        "Y": -10.852708,
+        "Z": -102.40727
+      },
+      "Arguments": [
+        "ObjectData;2001625; IsTargetable;FALSE & ModifyIndex;+3"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Winch is not targetable / already interacted with."
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
+        "X": 43.43475,
+        "Y": -11.040856,
+        "Z": -85.47054
       },
       "Arguments": [
         "2001625"
@@ -186,9 +290,21 @@
       "Tag": "Treasure",
       "Name": "TreasureCoffer",
       "Position": {
-        "X": 41.44,
-        "Y": -10.89,
-        "Z": -84.35
+        "X": 41.65467,
+        "Y": -10.900485,
+        "Z": -84.30613
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "Chance to spawn after using a Winch."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "MoveTo",
+      "Position": {
+        "X": -22.407799,
+        "Y": 0.16448319,
+        "Z": -131.95642
       },
       "Arguments": [
         ""
@@ -197,36 +313,54 @@
       "Note": ""
     },
     {
-      "Tag": "None",
+      "Tag": "Unsynced",
       "Name": "MoveTo",
       "Position": {
-        "X": -13.74324,
-        "Y": -1.5165342,
-        "Z": -116.668564
+        "X": -17.174164,
+        "Y": -11.172751,
+        "Z": -137.87387
       },
-      "Arguments": [],
+      "Arguments": [
+        "FALSE"
+      ],
       "Conditions": [],
       "Note": ""
     },
     {
-      "Tag": "None",
-      "Name": "MoveTo",
+      "Tag": "Unsynced",
+      "Name": "ConditionAction",
       "Position": {
-        "X": -5.7234087,
-        "Y": -10.661033,
-        "Z": -187.30362
+        "X": -7.7070127,
+        "Y": -11.060599,
+        "Z": -154.04617
       },
-      "Arguments": [],
+      "Arguments": [
+        "ObjectData;2001626; IsTargetable;FALSE & ModifyIndex;+4"
+      ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Skips ahead if the Winch is not targetable / already interacted with."
+    },
+    {
+      "Tag": "Synced",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -4.6182775,
+        "Y": -10.740324,
+        "Z": -186.06813
+      },
+      "Arguments": [
+        "ObjectData;2001626; IsTargetable;FALSE & ModifyIndex;+3"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Winch is not targetable / already interacted with."
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
+        "X": 16.414598,
+        "Y": -10.966246,
+        "Z": -189.88957
       },
       "Arguments": [
         "2001626"
@@ -238,9 +372,21 @@
       "Tag": "Treasure",
       "Name": "TreasureCoffer",
       "Position": {
-        "X": 18.28,
-        "Y": -10.93,
-        "Z": -190.16
+        "X": 18.181356,
+        "Y": -10.928166,
+        "Z": -190.35655
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "Chance to spawn after using a Winch."
+    },
+    {
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
+      "Position": {
+        "X": 30.598001,
+        "Y": -15.7974205,
+        "Z": -132.61546
       },
       "Arguments": [
         ""
@@ -250,23 +396,25 @@
     },
     {
       "Tag": "None",
-      "Name": "MoveTo",
+      "Name": "ConditionAction",
       "Position": {
-        "X": -31.192667,
-        "Y": -11.049809,
-        "Z": -127.65173
+        "X": -27.864107,
+        "Y": -11.039474,
+        "Z": -132.42632
       },
-      "Arguments": [],
+      "Arguments": [
+        "ObjectData;2001627; IsTargetable;FALSE & ModifyIndex;+3"
+      ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Skips ahead if the Winch is not targetable / already interacted with."
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
+        "X": -37.440296,
+        "Y": -11.070918,
+        "Z": -128.69514
       },
       "Arguments": [
         "2001627"
@@ -275,24 +423,38 @@
       "Note": "Chain Winch"
     },
     {
-      "Tag": "None",
-      "Name": "MoveTo",
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
       "Position": {
-        "X": -71.372,
-        "Y": -10.794906,
-        "Z": -107.85388
+        "X": -39.07413,
+        "Y": -11.066986,
+        "Z": -129.17693
       },
       "Arguments": [],
       "Conditions": [],
-      "Note": ""
+      "Note": "Chance to spawn after using a Winch."
+    },
+    {
+      "Tag": "None",
+      "Name": "ConditionAction",
+      "Position": {
+        "X": -72.52052,
+        "Y": -10.951139,
+        "Z": -110.87921
+      },
+      "Arguments": [
+        "ObjectData;2001628; IsTargetable;FALSE & ModifyIndex;+3"
+      ],
+      "Conditions": [],
+      "Note": "Skips ahead if the Winch is not targetable / already interacted with."
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
+        "X": -81.42801,
+        "Y": -11.029103,
+        "Z": -112.195435
       },
       "Arguments": [
         "2001628"
@@ -301,12 +463,36 @@
       "Note": "Chain Winch"
     },
     {
-      "Tag": "None",
-      "Name": "MoveTo",
+      "Tag": "Treasure",
+      "Name": "TreasureCoffer",
       "Position": {
-        "X": -119.09809,
-        "Y": -6.2826014,
-        "Z": -110.3725
+        "X": -82.42086,
+        "Y": -10.93343,
+        "Z": -113.425186
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "Chance to spawn after using a Winch."
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 2 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [],
       "Conditions": [],
@@ -316,47 +502,23 @@
       "Tag": "None",
       "Name": "Boss",
       "Position": {
-        "X": -179.64,
-        "Y": -15.31,
-        "Z": -132.33
+        "X": -182.74692,
+        "Y": -15.306585,
+        "Z": -132.63612
       },
       "Arguments": [
         ""
       ],
       "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": -183.59157,
-        "Y": -15.306585,
-        "Z": -135.03816
-      },
-      "Arguments": [],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": -183.35744,
-        "Y": -15.306585,
-        "Z": -135.50076
-      },
-      "Arguments": [],
-      "Conditions": [],
-      "Note": ""
+      "Note": "Thunderclap Guivre"
     },
     {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
+        "X": -178.0384,
+        "Y": -15.306587,
+        "Z": -133.69275
       },
       "Arguments": [
         "2001647"
@@ -379,6 +541,18 @@
       "Note": ""
     },
     {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Trash Packs / 雑魚 -->"
+    },
+    {
       "Tag": "None",
       "Name": "WaitFor",
       "Position": {
@@ -393,24 +567,40 @@
       "Note": ""
     },
     {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "None",
       "Name": "MoveTo",
       "Position": {
-        "X": -159.9117,
-        "Y": 9.060096,
-        "Z": -13.877168
+        "X": -138.34854,
+        "Y": 5.640684,
+        "Z": -28.227573
       },
-      "Arguments": [],
+      "Arguments": [
+        ""
+      ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Helps avoid slightly janky pathing."
     },
     {
       "Tag": "Treasure",
       "Name": "TreasureCoffer",
       "Position": {
-        "X": -121.42,
-        "Y": 9.83,
-        "Z": -1.11
+        "X": -122.82572,
+        "Y": 9.833187,
+        "Z": -1.0819875
       },
       "Arguments": [
         ""
@@ -419,18 +609,56 @@
       "Note": ""
     },
     {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -168.72563,
+        "Y": 12.558849,
+        "Z": 10.897344
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
-        "X": -172.88,
-        "Y": 12.66,
-        "Z": 11.6
+        "X": -172.20668,
+        "Y": 12.661985,
+        "Z": 12.365979
       },
       "Arguments": [
         "2001623"
       ],
       "Conditions": [],
       "Note": "Ludus Door"
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Boss / ボス 3 -->"
+    },
+    {
+      "Tag": "Revival",
+      "Name": "Revival",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
     },
     {
       "Tag": "None",
@@ -444,19 +672,19 @@
         ""
       ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Tangata"
     }
   ],
   "Meta": {
-    "CreatedAt": 175,
+    "CreatedAt": 285,
     "Changelog": [
       {
-        "Version": 189,
-        "Change": "Adjusted tags to string values"
+        "Version": 297,
+        "Change": ""
       },
       {
-        "Version": 290,
-        "Change": "Removed trying to avoid patrol"
+        "Version": 298,
+        "Change": ""
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(196) The Final Coil of Bahamut - Turn 4.json
+++ b/AutoDuty/Paths/(196) The Final Coil of Bahamut - Turn 4.json
@@ -1,0 +1,23 @@
+{
+  "Actions": [
+    {
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 449.946,
+        "Y": 0.0,
+        "Z": -5.049
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": "Bahamut Prime"
+    }
+  ],
+  "Meta": {
+    "CreatedAt": 285,
+    "Changelog": [],
+    "Notes": []
+  }
+}

--- a/AutoDuty/Paths/(584) Alexander - The Eyes of the Creator (Savage).json
+++ b/AutoDuty/Paths/(584) Alexander - The Eyes of the Creator (Savage).json
@@ -2,15 +2,16 @@
   "Actions": [
     {
       "Tag": "None",
-      "Name": "Boss",
+      "Name": "WaitFor",
       "Position": {
-        "X": -38.98,
-        "Y": 114.71,
-        "Z": -4.16
+        "X": -39.60939,
+        "Y": 114.710785,
+        "Z": -0.35883564
       },
       "Arguments": [
-        ""
+        "Combat"
       ],
+      "Conditions": [],
       "Note": ""
     },
     {
@@ -24,6 +25,7 @@
       "Arguments": [
         "2007455"
       ],
+      "Conditions": [],
       "Note": "Cranial Hatch"
     },
     {
@@ -37,6 +39,7 @@
       "Arguments": [
         "2007456"
       ],
+      "Conditions": [],
       "Note": "Ingress"
     },
     {
@@ -50,30 +53,7 @@
       "Arguments": [
         "IsReady"
       ],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "WaitFor",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "IsReady"
-      ],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 0.041660503,
-        "Y": -250.29001,
-        "Z": -239.65451
-      },
-      "Arguments": [],
+      "Conditions": [],
       "Note": ""
     },
     {
@@ -87,38 +67,13 @@
       "Arguments": [
         ""
       ],
-      "Note": ""
-    },
-    {
-      "Tag": "None",
-      "Name": "WaitFor",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "IsReady"
-      ],
+      "Conditions": [],
       "Note": ""
     }
   ],
   "Meta": {
-    "CreatedAt": 173,
-    "Changelog": [
-      {
-        "Version": 173,
-        "Change": "kuku"
-      },
-      {
-        "Version": 189,
-        "Change": "Adjusted tags to string values"
-      },
-      {
-        "Version": 231,
-        "Change": "Added IsReady checks"
-      }
-    ],
+    "CreatedAt": 285,
+    "Changelog": [],
     "Notes": []
   }
 }


### PR DESCRIPTION
   1.) Updated the paths for the first five ARR dungeons as the first step towards updating / standardizing all dungeons in the game. Added steps such as Treasure Chests, Unsynced stuff, ConditionAction, Revivals, etc. Also added more notes to steps for clarity. Basically I just want to make sure there's nothing wrong with these five paths before working on updating more.

   IMPORTANT NOTE: I left spaces in the ConditionAction steps (cuz of my OCD) which means the paths WILL NOT WORK CORRECTLY unless ConditionAction is adjusted to work with spaces, as per the brief discussion we had in the Discord server. Yeah, I uploaded these operating under the assumption you could make that happen tbh. If you can't then it's not a big deal, lmk and I'll adjust these paths and keep it in mind for the future.

   I have no idea if it was necessary to put ConditionAction "failsafe" steps before, like, every interaction but I figured: That's what failsafes are for, so it couldn't hurt. If you think it's excessive or something, lmk and I'll adjust 'em.

   2.) I assume the new path for Final Coil of Bahamut T4 doesn't need an explanation.

   3.) Made some small adjustments to the current Eyes of the Creator (Savage) path to make it more streamlined / up-to-date. WaitFor: Combat instead of Boss as the first step, and removed excess steps when falling down to the second area.