### PR TITLE
Adding SetLevelingMode IPC

### DIFF
--- a/AutoDuty/AutoDuty.json
+++ b/AutoDuty/AutoDuty.json
@@ -2,11 +2,11 @@
   "Author": "Herculezz, erdelf",
   "Name": "AutoDuty",
   "Punchline": "AutoDuty",
-  "Description": "A plugin to run dungeons for you with Trust, Duty Support, Squadrons, Variants, and Regular, Requires BossMod, vnavmesh and a Rotation Plugin (Wrath Combo, BossMod AutoRotation, or RotationSolverReborn).",
+  "Description": "A plugin to run dungeons for you with Trust, Duty Support, Squadrons, Variants, and Regular, Requires BossMod, vnavmesh and a Rotation Plugin (Wrath Combo, BossMod AutoRotation, or RotationSolverReborn)",
   "InternalName": "AutoDuty",
   "DalamudApiLevel": "14",
   "MinimumDalamudVersion": "14.0.0.0",
-  "RepoUrl": "https://github.com/JerVenture/AutoDutyForkedJer",
+  "RepoUrl": "https://github.com/erdelf/AutoDuty",
   "IconUrl": "https://s3.puni.sh/media/plugin/54/icon-15ug2vnr9m1.png",
   "ImageUrls": [
     "https://s3.puni.sh/media/plugin/54/image-15l1o9gf3yg.png",


### PR DESCRIPTION
I have been working on a plugin to automatically swap classes after reaching a designated level, so it can then continue leveling a separate class. An issue that I have been encountering is that I get an error "unable to load content for territory." This happens any time it swaps from one class to the next, and I think it's largely an issue of it trying to load dungeons for a class that is not yet a high enough level for said dungeons. However, swapping the leveling mode from auto to none and back to auto seems to fix said issue. I just added an IPC to set the leveling mode that I can call from the other plugin I'm making. I would be very grateful if you added it into the main plugin! 

Thank you for your time,
JerVenture

P.S. I'm new to the developer community, so if there's any sort of improvement I need to make on my etiquette or if I did anything wrong, please let me know!