### PR TITLE
Small Adjustments to Misc. Paths

### DIFF
--- a/AutoDuty/Paths/(1043) Castrum Meridianum.json
+++ b/AutoDuty/Paths/(1043) Castrum Meridianum.json
@@ -365,6 +365,20 @@
     },
     {
       "Tag": "Synced, W2W",
+      "Name": "BossMod",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ON"
+      ],
+      "Conditions": [],
+      "Note": " Allows BossMod AI to dodge AoEs while waiting."
+    },
+    {
+      "Tag": "Synced, W2W",
       "Name": "Wait",
       "Position": {
         "X": -47.64706,
@@ -400,7 +414,7 @@
         "Z": 151.62589
       },
       "Arguments": [
-        "1000"
+        "2500"
       ],
       "Conditions": [
         {
@@ -412,33 +426,14 @@
     },
     {
       "Tag": "Synced, W2W",
-      "Name": "Wait",
+      "Name": "MoveTo",
       "Position": {
-        "X": -58.254562,
-        "Y": 73.55941,
-        "Z": 151.98991
+        "X": -54.23309,
+        "Y": 73.26647,
+        "Z": 175.09642
       },
       "Arguments": [
-        "1000"
-      ],
-      "Conditions": [
-        {
-          "$type": "AutoDuty.Data.Classes+PathActionConditionJob, AutoDuty",
-          "job": "Tanks"
-        }
-      ],
-      "Note": "Attempts to dodge AoEs while still grabbing aggro."
-    },
-    {
-      "Tag": "Synced, W2W",
-      "Name": "Wait",
-      "Position": {
-        "X": -54.66288,
-        "Y": 73.33443,
-        "Z": 171.9976
-      },
-      "Arguments": [
-        "1500"
+        ""
       ],
       "Conditions": [
         {
@@ -505,7 +500,21 @@
         "FALSE"
       ],
       "Conditions": [],
-      "Note": ""
+      "Note": "May not trigger before the next set of enemies runs at you depending on where the previous battle finished."
+    },
+    {
+      "Tag": "Synced, W2W",
+      "Name": "BossMod",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ON"
+      ],
+      "Conditions": [],
+      "Note": " Allows BossMod AI to dodge AoEs while waiting."
     },
     {
       "Tag": "Synced, W2W",
@@ -544,7 +553,7 @@
         "Z": 86.47968
       },
       "Arguments": [
-        "2000"
+        "2500"
       ],
       "Conditions": [
         {
@@ -556,14 +565,14 @@
     },
     {
       "Tag": "Synced, W2W",
-      "Name": "Wait",
+      "Name": "MoveTo",
       "Position": {
-        "X": -21.920557,
-        "Y": 74.22513,
-        "Z": 102.2514
+        "X": -23.196875,
+        "Y": 74.26662,
+        "Z": 104.31726
       },
       "Arguments": [
-        "2000"
+        ""
       ],
       "Conditions": [
         {

--- a/AutoDuty/Paths/(1062) Snowcloak.json
+++ b/AutoDuty/Paths/(1062) Snowcloak.json
@@ -292,15 +292,41 @@
       "Note": ""
     },
     {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Gauntlet Loop: Start -->"
+    },
+    {
+      "Tag": "None",
+      "Name": "KillInRange",
+      "Position": {
+        "X": -58.033283,
+        "Y": 28.4,
+        "Z": -9.250649
+      },
+      "Arguments": [
+        "33"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "None",
       "Name": "Wait",
       "Position": {
-        "X": -58.02484,
-        "Y": 28.400002,
-        "Z": -9.161681
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
-        "250"
+        "1000"
       ],
       "Conditions": [],
       "Note": ""
@@ -314,17 +340,17 @@
         "Z": 0.0
       },
       "Arguments": [
-        "+2"
+        "-2"
       ],
       "Conditions": [
         {
           "$type": "AutoDuty.Data.Classes+PathActionConditionObjectData, AutoDuty",
-          "baseId": 3356,
+          "baseId": 3364,
           "property": "IsTargetable",
           "value": 1
         }
       ],
-      "Note": "Skips ahead if the Snowclops is targetable."
+      "Note": "Goes back if an Ice Bomb is targetable (enemies in the first wave)."
     },
     {
       "Tag": "None",
@@ -335,10 +361,43 @@
         "Z": 0.0
       },
       "Arguments": [
-        "-2"
+        "-3"
+      ],
+      "Conditions": [
+        {
+          "$type": "AutoDuty.Data.Classes+PathActionConditionObjectData, AutoDuty",
+          "baseId": 3376,
+          "property": "IsTargetable",
+          "value": 1
+        }
+      ],
+      "Note": "Goes back if the Hybrid Gator is targetable (an enemy in the second wave)."
+    },
+    {
+      "Tag": "None",
+      "Name": "KillInRange",
+      "Position": {
+        "X": -58.033283,
+        "Y": 28.4,
+        "Z": -9.250649
+      },
+      "Arguments": [
+        "30"
       ],
       "Conditions": [],
-      "Note": "Goes back and waits some more."
+      "Note": ""
+    },
+    {
+      "Tag": "Comment",
+      "Name": "<-- Comment -->",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": "<-- Gauntlet Loop: End -->"
     },
     {
       "Tag": "None",
@@ -430,7 +489,7 @@
       },
       {
         "Version": 299,
-        "Change": "Added Trash/Boss Comments & Boss Names. Added Unsynced Steps. Added KillInRange steps. Replaced the Boss step in the Gauntlet after the second boss with a Condition."
+        "Change": "Added Trash/Boss Comments & Boss Names. Added Unsynced Steps. Added KillInRange steps. Replaced the Boss step in the Gauntlet after the second boss with a Condition loop."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(193) The Final Coil of Bahamut - Turn 1.json
+++ b/AutoDuty/Paths/(193) The Final Coil of Bahamut - Turn 1.json
@@ -1,12 +1,40 @@
 {
   "Actions": [
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 0.019999996,
+        "Y": 0.48,
+        "Z": 167.0802
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": "Helps make sure you don't walk into the port back to the previous area while targeting enemies."
+    },
+    {
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
-        "X": -0.22866067,
-        "Y": -2.9802322E-06,
-        "Z": 178.44711
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
         "IsReady"
@@ -15,82 +43,26 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
+      "Tag": "None",
+      "Name": "StopForCombat",
       "Position": {
-        "X": 0.019999996,
-        "Y": 0.18,
-        "Z": 165.98013
+        "X": 2.6317458,
+        "Y": -20.000004,
+        "Z": 133.07559
       },
       "Arguments": [
-        ""
+        "TRUE"
       ],
       "Conditions": [],
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 2.5186815,
-        "Y": -19.931221,
-        "Z": 140.62509
-      },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 20.277357,
-        "Y": -20.0,
-        "Z": 120.30451
-      },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 21.60231,
-        "Y": -19.999996,
-        "Z": 97.47488
-      },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 1.2295529,
-        "Y": -20.0,
-        "Z": 95.77714
-      },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": -0.07044729,
-        "Y": -20.0,
-        "Z": 76.277435
+        "Y": -19.599998,
+        "Z": 79.47739
       },
       "Arguments": [
         ""
@@ -99,53 +71,53 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
+      "Tag": "None",
+      "Name": "StopForCombat",
       "Position": {
-        "X": 6.7099476,
-        "Y": -30.0,
-        "Z": 30.417242
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
-        ""
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": "Helps make sure you don't walk into the port back to the previous area while targeting enemies."
+    },
+    {
+      "Tag": "None",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "IsReady"
       ],
       "Conditions": [],
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
+      "Tag": "None",
+      "Name": "StopForCombat",
       "Position": {
-        "X": 21.966839,
+        "X": 18.498104,
         "Y": -29.999998,
-        "Z": 28.603163
+        "Z": 20.187124
       },
       "Arguments": [
-        ""
+        "TRUE"
       ],
       "Conditions": [],
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
-      "Position": {
-        "X": 20.432076,
-        "Y": -29.999996,
-        "Z": 11.195478
-      },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": -0.69515115,
-        "Y": -29.817951,
+        "Y": -29.71795,
         "Z": 9.553051
       },
       "Arguments": [
@@ -155,7 +127,33 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "IsReady"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 2.8740585,
+        "Y": -5.0,
+        "Z": -156.63664
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": -0.12323623,
@@ -169,7 +167,21 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "IsReady"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": 0.3343301,
@@ -183,15 +195,15 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "Boss",
       "Position": {
-        "X": -1.0962937,
+        "X": -0.069610015,
         "Y": -1.1920929E-06,
-        "Z": -291.7352
+        "Z": -306.76794
       },
       "Arguments": [
-        "3288"
+        ""
       ],
       "Conditions": [],
       "Note": "Imdugud"
@@ -199,7 +211,12 @@
   ],
   "Meta": {
     "CreatedAt": 298,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 299,
+        "Change": "Added WaitFor:IsReady during forced movement. Added short StopForCombat segments to avoid accidentally stepping on the back-teleporters. Removed excess MoveTo steps. Removed Unsynced tags since it should work perfectly fine while Synced?"
+      }
+    ],
     "Notes": []
   }
 }

--- a/AutoDuty/Paths/(194) The Final Coil of Bahamut - Turn 2.json
+++ b/AutoDuty/Paths/(194) The Final Coil of Bahamut - Turn 2.json
@@ -1,7 +1,7 @@
 {
   "Actions": [
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": 3.0817413,
@@ -15,7 +15,7 @@
       "Note": "Jump Right"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -23,32 +23,18 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "WaitFor",
-      "Position": {
-        "X": 73.65923,
-        "Y": 79.699646,
-        "Z": 279.601
-      },
-      "Arguments": [
-        "IsReady"
-      ],
-      "Conditions": [],
-      "Note": "Kill Mobs To Activate Panel"
-    },
-    {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
-        "X": 69.24264,
-        "Y": 74.42858,
-        "Z": 256.7734
+        "X": 68.742645,
+        "Y": 74.228584,
+        "Z": 256.8734
       },
       "Arguments": [
         ""
@@ -57,7 +43,7 @@
       "Note": "Jump Left"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -65,27 +51,27 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Wait For Jump To Complete"
+      "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "WaitFor",
+      "Tag": "None",
+      "Name": "StopForCombat",
       "Position": {
-        "X": -0.33532017,
-        "Y": -60.85809,
-        "Z": 236.70218
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
-        "IsReady"
+        "FALSE"
       ],
       "Conditions": [],
-      "Note": "Kill Mobs To Start Timer"
+      "Note": ""
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "Wait",
       "Position": {
         "X": -0.3915292,
@@ -93,13 +79,27 @@
         "Z": 236.83199
       },
       "Arguments": [
-        "15000"
+        "14000"
       ],
       "Conditions": [],
       "Note": "Wait For Panel #1 To Activate"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
       "Name": "Wait",
       "Position": {
         "X": -0.26097775,
@@ -107,13 +107,13 @@
         "Z": 223.98341
       },
       "Arguments": [
-        "15000"
+        "14000"
       ],
       "Conditions": [],
       "Note": "Wait For Panel #2 To Activate"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": 5.5540257,
@@ -127,7 +127,7 @@
       "Note": "Go Back To Center"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -135,31 +135,17 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Wait For Jump To Complete"
+      "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "WaitFor",
-      "Position": {
-        "X": 74.4351,
-        "Y": 2.1499379,
-        "Z": 128.32402
-      },
-      "Arguments": [
-        "IsReady"
-      ],
-      "Conditions": [],
-      "Note": "Kill Mobs To Activate Panel"
-    },
-    {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
-        "X": 63.702248,
-        "Y": 2.349938,
+        "X": 62.702263,
+        "Y": 2.4499378,
         "Z": 108.99034
       },
       "Arguments": [
@@ -169,7 +155,7 @@
       "Note": "Jump To Left Of Semi-Circle"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -177,116 +163,102 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Wait For Jump To Complete"
+      "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "Wait",
+      "Tag": "None",
+      "Name": "StopForCombat",
       "Position": {
-        "X": -33.990288,
-        "Y": 1.05597,
-        "Z": 56.749283
+        "X": -33.61982,
+        "Y": 1.2229955,
+        "Z": 56.9418
       },
       "Arguments": [
-        "15000"
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": "Makes sure you won't walk off the panel to target the patrolling enemy."
+    },
+    {
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
+        "X": -33.61982,
+        "Y": 1.2229955,
+        "Z": 56.9418
+      },
+      "Arguments": [
+        "14000"
       ],
       "Conditions": [],
       "Note": "Wait For Panel To Activate"
     },
     {
-      "Tag": "Unsynced",
-      "Name": "CameraFacing",
-      "Position": {
-        "X": -33.99,
-        "Y": 1.06,
-        "Z": 56.75
-      },
-      "Arguments": [
-        "-18.15, 0.72, 62.79"
-      ],
-      "Conditions": [],
-      "Note": "Face Barrier"
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "ChatCommand",
+      "Tag": "None",
+      "Name": "StopForCombat",
       "Position": {
         "X": 0.0,
         "Y": 0.0,
         "Z": 0.0
       },
       "Arguments": [
-        "/automove"
-      ],
-      "Conditions": [],
-      "Note": "Kill Yourself To Respawn"
-    },
-    {
-      "Tag": "Revival",
-      "Name": "Revival",
-      "Position": {
-        "X": -2.147861,
-        "Y": -95.83301,
-        "Z": 374.2467
-      },
-      "Arguments": [
-        "10000"
-      ],
-      "Conditions": [],
-      "Note": "Respawn"
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "MoveTo",
-      "Position": {
-        "X": -3.4515095,
-        "Y": -86.134735,
-        "Z": 329.38394
-      },
-      "Arguments": [
-        ""
-      ],
-      "Conditions": [],
-      "Note": "Jump Left"
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "WaitFor",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "TRUE"
       ],
       "Conditions": [],
       "Note": ""
     },
     {
       "Tag": "Unsynced",
+      "Name": "Jump",
+      "Position": {
+        "X": -23.380667,
+        "Y": 0.578985,
+        "Z": 60.788483
+      },
+      "Arguments": [
+        "250"
+      ],
+      "Conditions": [],
+      "Note": " Jumps into the death wall. Necessary to be on the SelectYes step if the rez bug happens."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "SelectYesno",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "Yes"
+      ],
+      "Conditions": [],
+      "Note": "This will accept the rez if AD bugs out and doesn't for reason."
+    },
+    {
+      "Tag": "Unsynced",
       "Name": "WaitFor",
       "Position": {
-        "X": -79.24579,
-        "Y": 55.34176,
-        "Z": 290.877
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
         "IsReady"
       ],
       "Conditions": [],
-      "Note": "Kill Mobs To Activate Panel"
+      "Note": ""
     },
     {
       "Tag": "Unsynced",
       "Name": "MoveTo",
       "Position": {
-        "X": -71.37628,
-        "Y": 50.939503,
-        "Z": 262.61926
+        "X": 3.082,
+        "Y": -86.021,
+        "Z": 329.9
       },
       "Arguments": [
         ""
@@ -295,7 +267,7 @@
       "Note": "Jump Right"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -303,10 +275,38 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Wait For Jump To Complete"
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 68.743004,
+        "Y": 74.229004,
+        "Z": 256.87302
+      },
+      "Arguments": [
+        ""
+      ],
+      "Conditions": [],
+      "Note": "Jump Left"
+    },
+    {
+      "Tag": "None",
+      "Name": "WaitFor",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "ConditionFlag;Jumping61;FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
     },
     {
       "Tag": "Unsynced",
@@ -323,7 +323,7 @@
       "Note": "Jump Left"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -331,24 +331,10 @@
         "Z": 0.0
       },
       "Arguments": [
-        ""
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Wait For Jump To Complete"
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "WaitFor",
-      "Position": {
-        "X": -79.942986,
-        "Y": -11.665341,
-        "Z": 136.29092
-      },
-      "Arguments": [
-        "IsReady"
-      ],
-      "Conditions": [],
-      "Note": "Kill Mobs To Activate Panel"
+      "Note": ""
     },
     {
       "Tag": "Unsynced",
@@ -365,35 +351,63 @@
       "Note": "Jump To Right Of Semi-Circle"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
-        "X": 47.440807,
-        "Y": 0.57899773,
-        "Z": 45.12453
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
       "Arguments": [
-        "IsReady"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Kill Mobs"
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 33.914383,
+        "Y": 1.2578886,
+        "Z": 56.68622
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": "Makes sure you won't walk off the panel to target the patrolling enemy."
     },
     {
       "Tag": "Unsynced",
       "Name": "Wait",
       "Position": {
-        "X": 33.576286,
-        "Y": 1.1819022,
-        "Z": 56.955185
+        "X": 33.914383,
+        "Y": 1.2578886,
+        "Z": 56.68622
       },
       "Arguments": [
-        "15000"
+        "14000"
       ],
       "Conditions": [],
       "Note": "Wait For Panel To Activate"
     },
     {
       "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
         "X": -0.38482118,
@@ -407,7 +421,7 @@
       "Note": "Jump To Center"
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "WaitFor",
       "Position": {
         "X": 0.0,
@@ -415,18 +429,18 @@
         "Z": 0.0
       },
       "Arguments": [
-        "ConditionFlag;Jumping61;false"
+        "ConditionFlag;Jumping61;FALSE"
       ],
       "Conditions": [],
-      "Note": "Wait For Jump To Complete"
+      "Note": ""
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "MoveTo",
       "Position": {
-        "X": -1.1256757,
+        "X": 2.312538,
         "Y": -4.9630003,
-        "Z": 16.144495
+        "Z": 13.339716
       },
       "Arguments": [
         ""
@@ -435,15 +449,15 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
+      "Tag": "None",
       "Name": "Boss",
       "Position": {
-        "X": -1.13,
-        "Y": -4.96,
-        "Z": 16.14
+        "X": 0.4716593,
+        "Y": -4.9630003,
+        "Z": -4.535334
       },
       "Arguments": [
-        "3294"
+        ""
       ],
       "Conditions": [],
       "Note": "Kaliya"
@@ -451,7 +465,12 @@
   ],
   "Meta": {
     "CreatedAt": 298,
-    "Changelog": [],
+    "Changelog": [
+      {
+        "Version": 299,
+        "Change": "Adjusted the Unsynced tags to only be on the second set of steps going to the other side. Adjusted the death-wall part to work normally and with the weird rez bug I got initially. Removed excess steps waiting for after combat."
+      }
+    ],
     "Notes": []
   }
 }


### PR DESCRIPTION
1.) Slightly adjusted the W2W sections in Castrum Meridianium since I just learned how the BossMod step works in conjunction with StopForCombat:False, and manually moving to try and avoid AoEs is unnecessary when BossMod:On can do that instead.

2.) Adjusted the Gauntlet condition in Snowcloak since I realized that if anyone ever died in the area _after_ the Gauntlet and had to rez and run back through, the path would just get permanently stuck waiting for the Cyclops. The new Conditions have been tested to work properly during the Gauntlet, and not cause ppl to get stuck running back through if the Gauntlet is already done.

3.) Adjusted the Final Coil of Bahamut Turn 1 to be more consistent. The original path would occasionally skip steps during the forced-movement sections cuz there were no WaitFor:IsReady, and I once had it walk back into the wrong teleporter when it tried to target and walk towards an enemy. The changes are aimed at preventing those situations.

4.) Adjusted the Final Coil of Bahamut Turn 2 to be more consistent... I hope. Erisen and I discussed it in the server, but we're pretty sure the steps in the original path that were supposed to walk into the death wall were not actually doing anything, so they've been changed. For better or for worse, half my testing was done when my AD bugged out and wasn't auto-accepting the rez prompt... But the good news is that it fixed itself later, so I can confirm the path worked both normally _and_ when my AD was bugged. I tested it around 15 times or so in total and it worked each time; I can only hope the 'killing yourself intentionally' part works for the same for everyone else as it does for me. (I also made it go to the right instead of the left the second-time-around since it's a few seconds faster with less enemies to kill.)

~Katsu