### PR TITLE
Added Boss Names to ARR Trials

### DIFF
--- a/AutoDuty/Paths/(1045) The Bowl of Embers.json
+++ b/AutoDuty/Paths/(1045) The Bowl of Embers.json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 7.14,
-        "Y": 0,
-        "Z": 0.01
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 7.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ifrit"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1046) The Navel.json
+++ b/AutoDuty/Paths/(1046) The Navel.json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0.11,
-        "Y": -0,
-        "Z": -9.41
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -10.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Titan"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1047) The Howling Eye.json
+++ b/AutoDuty/Paths/(1047) The Howling Eye.json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.3,
-        "Y": -1.86,
-        "Z": -6.43
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 1.0,
+        "Y": -1.8766085,
+        "Z": -10.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Garuda"
     }
   ],
-  "meta": {
-    "createdAt": 127,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 127,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1048) The Porta Decumana.json
+++ b/AutoDuty/Paths/(1048) The Porta Decumana.json
@@ -1,65 +1,72 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -772.27,
-        "Y": -400.06,
-        "Z": -600.18
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -775.0,
+        "Y": -400.0,
+        "Z": -600.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "The Ultima Weapon"
     },
     {
-      "tag": "None",
-      "name": "Wait",
-      "position": {
+      "Tag": "None",
+      "Name": "Wait",
+      "Position": {
         "X": -689.56,
         "Y": -185.73,
         "Z": 480.35
       },
-      "arguments": [
+      "Arguments": [
         "5000"
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -704.09,
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -705.0,
         "Y": -185.66,
-        "Z": 479.97
+        "Z": 480.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "The Ultima Weapon"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss names."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1067) Thornmarch (Hard).json
+++ b/AutoDuty/Paths/(1067) Thornmarch (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.02,
-        "Y": 0,
-        "Z": -1.45
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -1.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Good King Moggle Mog XII"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
+++ b/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
@@ -247,12 +247,12 @@
       "Tag": "None",
       "Name": "KillInRange",
       "Position": {
-        "X": 26.743103,
-        "Y": 210.23207,
-        "Z": 190.17809
+        "X": 28.118292,
+        "Y": 211.63792,
+        "Z": 224.27837
       },
       "Arguments": [
-        "35"
+        "15"
       ],
       "Conditions": [],
       "Note": ""
@@ -275,12 +275,12 @@
       "Tag": "None",
       "Name": "KillInRange",
       "Position": {
-        "X": 81.55454,
-        "Y": 220.03775,
-        "Z": 272.58664
+        "X": 115.787544,
+        "Y": 221.89915,
+        "Z": 272.07303
       },
       "Arguments": [
-        "35"
+        "15"
       ],
       "Conditions": [],
       "Note": ""
@@ -731,11 +731,11 @@
         "Version": 189,
         "Change": "Adjusted tags to string values"
       },
-	  {
+      {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added W2W & Unsynced steps. Added WaitFor:IsReady during transitions. Added Conditions for if you die during the Elevator somehow. Replaced ForceAttack steps with KillInRange steps. Removed AutoMoveFor steps."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(142) The Dragon's Neck.json
+++ b/AutoDuty/Paths/(142) The Dragon's Neck.json
@@ -1,40 +1,32 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -255.1,
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -255.0,
         "Y": 19.07,
-        "Z": 18.31
+        "Z": 18.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
-    },
-    {
-      "tag": "Treasure",
-      "name": "TreasureCoffer",
-      "position": {
-        "X": -270.04,
-        "Y": 19.07,
-        "Z": 18.02
-      },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ultros & Typhon"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss names."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(281) The Whorleater (Hard).json
+++ b/AutoDuty/Paths/(281) The Whorleater (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0.05,
-        "Y": 0.01,
-        "Z": -14.31
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -15.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Leviathan"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(292) The Bowl of Embers (Hard).json
+++ b/AutoDuty/Paths/(292) The Bowl of Embers (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 6.76,
-        "Y": 0,
-        "Z": -0.35
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 7.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ifrit"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(293) The Navel (Hard).json
+++ b/AutoDuty/Paths/(293) The Navel (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0,
-        "Y": -0,
-        "Z": -8.95
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -10.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Titan"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(294) The Howling Eye (Hard).json
+++ b/AutoDuty/Paths/(294) The Howling Eye (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.43,
-        "Y": -1.95,
-        "Z": -14.56
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 1.0,
+        "Y": -1.8766085,
+        "Z": -10.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Garuda"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(295) The Bowl of Embers (Extreme).json
+++ b/AutoDuty/Paths/(295) The Bowl of Embers (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 6.76,
-        "Y": 0,
-        "Z": -0.35
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 7.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ifrit"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(296) The Navel (Extreme).json
+++ b/AutoDuty/Paths/(296) The Navel (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0,
-        "Y": -0,
-        "Z": -8.95
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -10.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Titan"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(297) The Howling Eye (Extreme).json
+++ b/AutoDuty/Paths/(297) The Howling Eye (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.43,
-        "Y": -1.95,
-        "Z": -14.56
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": -1.8692833,
+        "Z": -10.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Garuda"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(348) The Minstrel's Ballad Ultima's Bane.json
+++ b/AutoDuty/Paths/(348) The Minstrel's Ballad Ultima's Bane.json
@@ -1,40 +1,32 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0.1,
-        "Y": -0.13,
-        "Z": -1.69
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -1.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
-    },
-    {
-      "tag": "Treasure",
-      "name": "TreasureCoffer",
-      "position": {
-        "X": 0.03,
-        "Y": -0.09,
-        "Z": -12.14
-      },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Conditions": [],
+      "Note": "The Ultima Weapon"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name. Removed unnecessary TreasureCoffer step."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(359) The Whorleater (Extreme).json
+++ b/AutoDuty/Paths/(359) The Whorleater (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0.05,
-        "Y": 0.01,
-        "Z": -14.31
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -15.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Leviathan"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(364) Thornmarch (Extreme).json
+++ b/AutoDuty/Paths/(364) Thornmarch (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.02,
-        "Y": 0,
-        "Z": -1.45
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -1.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Good King Moggle Mog XII"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(366) Battle on the Big Bridge.json
+++ b/AutoDuty/Paths/(366) Battle on the Big Bridge.json
@@ -1,95 +1,74 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -129.2597,
-        "Y": 1.3145969,
-        "Z": -0.09031831
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -60.0,
+        "Y": 2.0,
+        "Z": 0.0
       },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -77.21873,
-        "Y": 1.4460518,
-        "Z": 0.09717287
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -57.69,
-        "Y": 2,
-        "Z": 0.1
-      },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Gilgamesh"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -5.588481,
-        "Y": 0,
-        "Z": -0.9230764
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -35.0,
+        "Y": 2.0,
+        "Z": 0.0
       },
-      "arguments": [],
-      "note": ""
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 34.72553,
-        "Y": -7.000001,
-        "Z": -0.76388246
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 100.0,
+        "Y": -7.0,
+        "Z": 0.0
       },
-      "arguments": [],
-      "note": ""
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 104.83039,
-        "Y": -5.532879,
-        "Z": 0.050939985
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 125.0,
+        "Y": -5.0,
+        "Z": 0.0
       },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 113.45,
-        "Y": -4.98,
-        "Z": 0.12
-      },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Gilgamesh"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss names. Added Unsynced steps. Removed excess MoveTo steps."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(368) A Relic Reborn the Chimera.json
+++ b/AutoDuty/Paths/(368) A Relic Reborn the Chimera.json
@@ -1,27 +1,32 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 535.81,
-        "Y": 348.65,
-        "Z": -739.21
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 543.5,
+        "Y": 348.4,
+        "Z": -745.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Dhorme Chimera"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name. Adjusted Coordinates to be within the boss' aggro radius."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(369) A Relic Reborn the Hydra.json
+++ b/AutoDuty/Paths/(369) A Relic Reborn the Hydra.json
@@ -1,27 +1,32 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -259.89,
-        "Y": 16.96,
-        "Z": 17.89
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -270.0,
+        "Y": 17.225,
+        "Z": 18.85
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Hydra"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name. Adjusted Coordinates to be within the boss' aggro radius."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(374) The Striking Tree (Hard).json
+++ b/AutoDuty/Paths/(374) The Striking Tree (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0.4,
-        "Y": 75.09,
-        "Z": 3.32
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 75.0,
+        "Z": 5.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ramuh"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(375) The Striking Tree (Extreme).json
+++ b/AutoDuty/Paths/(375) The Striking Tree (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -0.4,
-        "Y": 75.09,
-        "Z": 3.32
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 75.0,
+        "Z": 5.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Ramuh"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(377) The Akh Afah Amphitheatre (Hard).json
+++ b/AutoDuty/Paths/(377) The Akh Afah Amphitheatre (Hard).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.2,
-        "Y": 0,
-        "Z": -2.17
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -2.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Shiva"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(378) The Akh Afah Amphitheatre (Extreme).json
+++ b/AutoDuty/Paths/(378) The Akh Afah Amphitheatre (Extreme).json
@@ -1,39 +1,44 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.2,
-        "Y": 0,
-        "Z": -2.17
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -2.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Shiva"
     }
   ],
-  "meta": {
-    "createdAt": 106,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 106,
+    "Changelog": [
       {
-        "version": 161,
-        "change": "Converted to new JSON Structure"
+        "Version": 161,
+        "Change": "Converted to new JSON Structure"
       },
       {
-        "version": 163,
-        "change": "Converted to newer JSON Structure"
+        "Version": 163,
+        "Change": "Converted to newer JSON Structure"
       },
       {
-        "version": 164,
-        "change": "Converted to JSON Structure with Tags"
+        "Version": 164,
+        "Change": "Converted to JSON Structure with Tags"
       },
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(394) Urth's Fount.json
+++ b/AutoDuty/Paths/(394) Urth's Fount.json
@@ -1,27 +1,32 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 623.58,
-        "Y": 23.7,
-        "Z": 85.45
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 623.0,
+        "Y": 23.725,
+        "Z": 75.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Odin"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name. Adjusted Coordinates to be within the boss' aggro radius."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(396) Battle in the Big Keep.json
+++ b/AutoDuty/Paths/(396) Battle in the Big Keep.json
@@ -1,75 +1,46 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -147.64,
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -125.0,
         "Y": -2.8,
-        "Z": -0.5
+        "Z": 0.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Gilgamesh & Enkidu"
     },
     {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -114.96637,
-        "Y": -2.8000038,
-        "Z": 0.5902905
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": -20.0,
+        "Y": 0.0,
+        "Z": 0.0
       },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": -49.10786,
-        "Y": 0.088905215,
-        "Z": -0.22393066
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": -31.71,
-        "Y": 0.2,
-        "Z": -0.07
-      },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
-    },
-    {
-      "tag": "Treasure",
-      "name": "TreasureCoffer",
-      "position": {
-        "X": -15.74,
-        "Y": 0,
-        "Z": 0.04
-      },
-      "arguments": [
-        ""
-      ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Gilgamesh"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss names. Adjusted Coordinates to be within the boss' aggro radius. Removed excess MoveTo steps & unnecessary TreasureCoffer step."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }

--- a/AutoDuty/Paths/(426) The Chrysalis.json
+++ b/AutoDuty/Paths/(426) The Chrysalis.json
@@ -1,27 +1,32 @@
 {
-  "actions": [
+  "Actions": [
     {
-      "tag": "None",
-      "name": "Boss",
-      "position": {
-        "X": 0.04,
-        "Y": -0,
-        "Z": 8.01
+      "Tag": "None",
+      "Name": "Boss",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": -5.0
       },
-      "arguments": [
+      "Arguments": [
         ""
       ],
-      "note": ""
+      "Conditions": [],
+      "Note": "Nabriales"
     }
   ],
-  "meta": {
-    "createdAt": 170,
-    "changelog": [
+  "Meta": {
+    "CreatedAt": 170,
+    "Changelog": [
       {
-        "version": 189,
-        "change": "Adjusted tags to string values"
+        "Version": 189,
+        "Change": "Adjusted tags to string values"
+      },
+      {
+        "Version": 299,
+        "Change": "Added Boss name. Adjusted Coordinates to be within the boss' aggro radius."
       }
     ],
-    "notes": []
+    "Notes": []
   }
 }


### PR DESCRIPTION
I noted down the changes in the Changelogs, but I'll reiterate them here cuz why not.

1.) Added Boss names to all fights.

2.) Removed unnecessary TreasureCoffer steps from the one or two Trials that had them after Boss steps.

3.) Removed excess MoveTo steps that were just moving in a straight line in the few Trials that had multiple bosses (primarily Manderville stuff). Also added Unsynced steps in the, uh, Big Bridge one IIRC cuz it actually has random trash packs in between the bosses. lol

4.) Adjusted the Coordinates of the Trials where the coords were outside the boss' aggro radius. (Also rounded the X and Z coords for most fights to be nice, whole numbers to satisfy my OCD.)

Once again, the files on Github show a shitton of additions and deletions (despite my changes to most of them being miniscule) cuz everything is being capitalized in the files. :(

Edit: Added "Small Adjust to KillInRange steps" which slightly adjusted the Aetherochemical Research Facility path. More info can be found beside the name.