### PR TITLE
Slight Adjustments to Various ARR Paths

### DIFF
--- a/AutoDuty/Paths/(1036) Sastasha.json
+++ b/AutoDuty/Paths/(1036) Sastasha.json
@@ -339,6 +339,20 @@
       "Note": ""
     },
     {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
@@ -570,9 +584,13 @@
         "Version": 231,
         "Change": "Re-added last boss step."
       },
-	  {
+      {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps (primarily before the first boss). Added KillInRange steps. Added Treasure steps (and a note about the missing one)."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Unsynced StopForCombat:True before Interactables."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(1040) Haukke Manor.json
+++ b/AutoDuty/Paths/(1040) Haukke Manor.json
@@ -123,6 +123,20 @@
       "Note": ""
     },
     {
+      "Tag": "Unsynced, Treasure",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": -52.527733,
+        "Y": 0.0,
+        "Z": 25.399944
+      },
+      "Arguments": [
+        "TRUE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "Treasure",
       "Name": "Interactable",
       "Position": {
@@ -346,6 +360,20 @@
       "Note": ""
     },
     {
+      "Tag": "Unsynced, Treasure",
+      "Name": "KillInRange",
+      "Position": {
+        "X": -0.41079447,
+        "Y": -18.799992,
+        "Z": -28.63737
+      },
+      "Arguments": [
+        "15"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "Treasure",
       "Name": "Interactable",
       "Position": {
@@ -396,6 +424,20 @@
         "Z": -7.714097
       },
       "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced, Treasure",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 31.047821,
+        "Y": -18.8,
+        "Z": 30.363655
+      },
+      "Arguments": [
+        "TRUE"
+      ],
       "Conditions": [],
       "Note": ""
     },
@@ -623,20 +665,6 @@
       "Note": ""
     },
     {
-      "Tag": "Unsynced",
-      "Name": "StopForCombat",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "FALSE"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
@@ -693,20 +721,6 @@
       },
       "Arguments": [
         "25"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "StopForCombat",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "TRUE"
       ],
       "Conditions": [],
       "Note": ""
@@ -769,9 +783,13 @@
         "Version": 241,
         "Change": ""
       },
-	  {
+      {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps. Added more thorough Treasure steps. Removed excess MoveTo steps. Removed unnecessary Revival steps (the Revival placed after the Aetherial Flow was incorrect since AD will take the Revival Portal there and put you in front of the Flow)."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Unsynced StopForCombat:True and KillInRange before Interactables. Removed unnecessary Unsynced StopForCombat steps between second and third bosses."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(1041) Brayflox's Longstop.json
+++ b/AutoDuty/Paths/(1041) Brayflox's Longstop.json
@@ -271,18 +271,18 @@
       "Note": ""
     },
     {
-      "Tag": "Treasure",
+      "Tag": "None",
       "Name": "KillInRange",
       "Position": {
-        "X": 28.10787,
-        "Y": 13.501427,
-        "Z": -54.929825
+        "X": 28.122221,
+        "Y": 13.502937,
+        "Z": -54.971577
       },
       "Arguments": [
         "15"
       ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Kills the Comet Chasers to avoid potential targeting issues during the next boss fight."
     },
     {
       "Tag": "Treasure",
@@ -513,6 +513,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps. Added missing TreasureCoffer steps before the 2nd boss. Removed StopForCombat:False before the second boss."
+      },
+	  {
+        "Version": 300,
+        "Change": "Removed the Treasure Tag from the KillInRange before the second boss, so that the enemies on the cliff are always killed to avoid targeting issues during the second boss."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
+++ b/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
@@ -442,12 +442,12 @@
       "Tag": "None",
       "Name": "KillInRange",
       "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
+        "X": -360.19034,
+        "Y": -299.98392,
+        "Z": -249.84454
       },
       "Arguments": [
-        "25"
+        "15"
       ],
       "Conditions": [],
       "Note": "In case you die during the fight on the lift and the enemies don't engage automatically when you load back in."
@@ -734,6 +734,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added W2W & Unsynced steps. Added WaitFor:IsReady during transitions. Added Conditions for if you die during the Elevator somehow. Replaced ForceAttack steps with KillInRange steps. Removed AutoMoveFor steps."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Coords to the KillInRange on the Elevator."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(1245) Halatali.json
+++ b/AutoDuty/Paths/(1245) Halatali.json
@@ -203,6 +203,20 @@
       "Note": "Chance to spawn after using a Winch."
     },
     {
+      "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 45.9766,
+        "Y": -11.153701,
+        "Z": -88.850266
+      },
+      "Arguments": [
+        "15"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "None",
       "Name": "Interactable",
       "Position": {
@@ -252,6 +266,20 @@
       },
       "Arguments": [
         "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 10.026308,
+        "Y": -11.139838,
+        "Z": -184.75627
+      },
+      "Arguments": [
+        "15"
       ],
       "Conditions": [],
       "Note": ""
@@ -577,6 +605,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps. Added missing Treasure Chests. Added appropriate Revival steps. Removed excess MoveTo steps."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Unsynced KillInRange before Interactables."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(1267) The Sunken Temple of Qarn.json
+++ b/AutoDuty/Paths/(1267) The Sunken Temple of Qarn.json
@@ -41,6 +41,20 @@
       "Note": ""
     },
     {
+      "Tag": "Unsynced, Treasure",
+      "Name": "KillInRange",
+      "Position": {
+        "X": -138.89442,
+        "Y": -9.000015,
+        "Z": 61.952087
+      },
+      "Arguments": [
+        "15"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "Treasure",
       "Name": "Interactable",
       "Position": {
@@ -81,6 +95,20 @@
       ],
       "Conditions": [],
       "Note": "Treasure Coffer - Listed as Interactable since it's position is not static."
+    },
+    {
+      "Tag": "Unsynced, Treasure",
+      "Name": "KillInRange",
+      "Position": {
+        "X": -142.6626,
+        "Y": -10.708776,
+        "Z": -59.2824
+      },
+      "Arguments": [
+        "15"
+      ],
+      "Conditions": [],
+      "Note": ""
     },
     {
       "Tag": "Treasure",
@@ -149,20 +177,6 @@
       "Note": "<-- Trash Packs / 雑魚 -->"
     },
     {
-      "Tag": "Unsynced",
-      "Name": "StopForCombat",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "FALSE"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
       "Tag": "None",
       "Name": "MoveTo",
       "Position": {
@@ -175,34 +189,6 @@
       ],
       "Conditions": [],
       "Note": "To avoid getting stuck in the doorway."
-    },
-    {
-      "Tag": "None",
-      "Name": "KillInRange",
-      "Position": {
-        "X": -17.198425,
-        "Y": -18.012014,
-        "Z": -0.38783738
-      },
-      "Arguments": [
-        "10"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Treasure",
-      "Name": "KillInRange",
-      "Position": {
-        "X": 5.282711,
-        "Y": -19.0,
-        "Z": 15.12803
-      },
-      "Arguments": [
-        "10"
-      ],
-      "Conditions": [],
-      "Note": ""
     },
     {
       "Tag": "Treasure",
@@ -234,20 +220,6 @@
     },
     {
       "Tag": "Treasure",
-      "Name": "KillInRange",
-      "Position": {
-        "X": 8.979861,
-        "Y": -19.0,
-        "Z": -11.399259
-      },
-      "Arguments": [
-        "10"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Treasure",
       "Name": "Interactable",
       "Position": {
         "X": 8.983742,
@@ -275,6 +247,20 @@
       "Note": "To avoid getting stuck in the doorway."
     },
     {
+      "Tag": "Unsynced",
+      "Name": "StopForCombat",
+      "Position": {
+        "X": 33.706665,
+        "Y": -19.000145,
+        "Z": -21.823263
+      },
+      "Arguments": [
+        "FALSE"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
       "Tag": "None",
       "Name": "MoveTo",
       "Position": {
@@ -298,7 +284,75 @@
         "FALSE"
       ],
       "Conditions": [],
-      "Note": ""
+      "Note": "Hops over the ledge."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 45.786453,
+        "Y": -43.42574,
+        "Z": -60.90093
+      },
+      "Arguments": [
+        "20"
+      ],
+      "Conditions": [
+        {
+          "$type": "AutoDuty.Data.Classes+PathActionConditionDistance, AutoDuty",
+          "origin": "Object",
+          "originId": 1768,
+          "originLoc": {
+            "X": 0.0,
+            "Y": 0.0,
+            "Z": 0.0
+          },
+          "target": "Location",
+          "targetId": 0,
+          "targetLoc": {
+            "X": 45.786,
+            "Y": -43.426,
+            "Z": -60.901
+          },
+          "operatorValue": "<",
+          "distance": 20.0
+        }
+      ],
+      "Note": "Ensures The Condemned is killed for the GC Hunting Log (if it's to the right side of the area)."
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 91.90675,
+        "Y": -43.49106,
+        "Z": -34.729485
+      },
+      "Arguments": [
+        "20"
+      ],
+      "Conditions": [
+        {
+          "$type": "AutoDuty.Data.Classes+PathActionConditionDistance, AutoDuty",
+          "origin": "Object",
+          "originId": 1768,
+          "originLoc": {
+            "X": 0.0,
+            "Y": 0.0,
+            "Z": 0.0
+          },
+          "target": "Location",
+          "targetId": 0,
+          "targetLoc": {
+            "X": 91.907,
+            "Y": -43.491,
+            "Z": -34.729
+          },
+          "operatorValue": "<",
+          "distance": 20.0
+        }
+      ],
+      "Note": "Ensures The Condemned is killed for the GC Hunting Log (if it's to the left side of the area)."
     },
     {
       "Tag": "Unsynced",
@@ -365,6 +419,20 @@
       ],
       "Conditions": [],
       "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 67.43445,
+        "Y": -38.619816,
+        "Z": 59.271297
+      },
+      "Arguments": [
+        "30"
+      ],
+      "Conditions": [],
+      "Note": "Ensures The Condemned is killed for the GC Hunting Log."
     },
     {
       "Tag": "None",
@@ -478,9 +546,9 @@
       "Tag": "None",
       "Name": "KillInRange",
       "Position": {
-        "X": 114.566536,
-        "Y": -4.0000095,
-        "Z": -7.366951
+        "X": 116.55319,
+        "Y": -3.998668,
+        "Z": 0.15220636
       },
       "Arguments": [
         "15"
@@ -719,9 +787,9 @@
       "Tag": "Treasure",
       "Name": "TreasureCoffer",
       "Position": {
-        "X": 196.33774,
+        "X": 195.89056,
         "Y": -4.000017,
-        "Z": -37.119
+        "Z": -37.39741
       },
       "Arguments": [],
       "Conditions": [],
@@ -784,6 +852,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps. Added Treasure steps. Added KillInRanged steps. Removed SelectYesNo step."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Unsynced KillInRange before Interactables. Added Unsynced KillInRange steps before and after the second boss to help ensure enough ghosts are killed for the GC Hunting Log. Removed unnecessary KillInRange steps after the first boss and adjusted the position of the Unsynced StopForCombat:False there."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(159) The Wanderer's Palace.json
+++ b/AutoDuty/Paths/(159) The Wanderer's Palace.json
@@ -628,6 +628,20 @@
     },
     {
       "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 47.845745,
+        "Y": 7.83574,
+        "Z": -93.911095
+      },
+      "Arguments": [
+        "15"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
       "Name": "StopForCombat",
       "Position": {
         "X": 0.0,
@@ -763,7 +777,7 @@
       "Note": "Goes back if you do not have two Lantern Oils."
     },
     {
-      "Tag": "Synced",
+      "Tag": "None",
       "Name": "KillInRange",
       "Position": {
         "X": 113.87902,
@@ -771,7 +785,7 @@
         "Z": -145.81627
       },
       "Arguments": [
-        "20"
+        "15"
       ],
       "Conditions": [],
       "Note": ""
@@ -1082,6 +1096,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced & Synced steps. Added KillInRange steps. Added various Checks and Conditions for Lantern Oil. Added various Conditions to Interactables between first and second boss so that they're skipped if already done. Removed excess MoveTo steps."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Unsynced KillInRange before Interactable."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(365) The Stone Vigil (Hard).json
+++ b/AutoDuty/Paths/(365) The Stone Vigil (Hard).json
@@ -150,6 +150,20 @@
     },
     {
       "Tag": "Unsynced",
+      "Name": "KillInRange",
+      "Position": {
+        "X": 2.1314,
+        "Y": 5.9604645E-06,
+        "Z": -58.43811
+      },
+      "Arguments": [
+        "15"
+      ],
+      "Conditions": [],
+      "Note": ""
+    },
+    {
+      "Tag": "Unsynced",
       "Name": "StopForCombat",
       "Position": {
         "X": 3.0425086,
@@ -636,6 +650,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps. Added Treasure steps. Added KillInRange steps. Added Conditions/Loop to complete the Bertha-clicking encounter. Added Condition to not leave the 3rd boss fight early. Removed excess MoveTo steps."
+      },
+      {
+        "Version": 300,
+        "Change": "Added Unsynced KillInRange to ensure the transforming enemy is killed before moving on."
       }
     ],
     "Notes": []

--- a/AutoDuty/Paths/(367) The Sunken Temple of Qarn (Hard).json
+++ b/AutoDuty/Paths/(367) The Sunken Temple of Qarn (Hard).json
@@ -13,34 +13,6 @@
       "Note": "<-- Trash Packs / 雑魚 -->"
     },
     {
-      "Tag": "Unsynced",
-      "Name": "WaitFor",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "IsReady"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "StopForCombat",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "FALSE"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
       "Tag": "None",
       "Name": "KillInRange",
       "Position": {
@@ -106,20 +78,6 @@
       },
       "Arguments": [
         "10"
-      ],
-      "Conditions": [],
-      "Note": ""
-    },
-    {
-      "Tag": "Unsynced",
-      "Name": "StopForCombat",
-      "Position": {
-        "X": 0.0,
-        "Y": 0.0,
-        "Z": 0.0
-      },
-      "Arguments": [
-        "TRUE"
       ],
       "Conditions": [],
       "Note": ""
@@ -594,6 +552,10 @@
       {
         "Version": 299,
         "Change": "Added Trash/Boss Comments & Boss names. Added Unsynced steps. Added KillInRange steps. Added WaitFor:IsReady after transitions. Added Condition to not leave the 1st boss fight early. Removed AutoMoveFor steps. Removed excess MoveTo steps."
+      },
+      {
+        "Version": 300,
+        "Change": "Removed somewhat pointless Unsynced steps at the start."
       }
     ],
     "Notes": []


### PR DESCRIPTION
Adjusted Brayflox and Sunken Temple of Qarn with the changes discussed in the server. Also went over the rest of the ARR dungeons and made slight adjustments where necessary to help ensure enemies are killed before Interactables, to avoid getting interrupted while Interacting (to smooth things out for ppl that can't kill all the enemies before getting there). Exact details can be found in the paths' changelogs.

~Katsu

Edit: Once again, I've uploaded ARF in a PR titled "ARR Paths". Such is life. IIRC I tested and KillInRange without coords does nothing, so I added coords to the one on the elevator in ARF.