### PR TITLE
docs: add multilingual README with language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<a href="README.md"><img src="https://flagcdn.com/24x18/gb.png" alt="EN"> English</a> · <a href="docs/README.fr.md"><img src="https://flagcdn.com/24x18/fr.png" alt="FR"> Français</a> · <a href="docs/README.ja.md"><img src="https://flagcdn.com/24x18/jp.png" alt="JA"> 日本語</a> · <a href="docs/README.zh-CN.md"><img src="https://flagcdn.com/24x18/cn.png" alt="ZH-CN"> 简体中文</a> · <a href="docs/README.zh-TW.md"><img src="https://flagcdn.com/24x18/tw.png" alt="ZH-TW"> 繁體中文</a>
+
 # AutoDuty
 
 <img align="right" width="150" height="150" src="logo.png">

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -1,0 +1,74 @@
+<a href="../README.md"><img src="https://flagcdn.com/24x18/gb.png" alt="EN"> English</a> · <a href="README.fr.md"><img src="https://flagcdn.com/24x18/fr.png" alt="FR"> Français</a> · <a href="README.ja.md"><img src="https://flagcdn.com/24x18/jp.png" alt="JA"> 日本語</a> · <a href="README.zh-CN.md"><img src="https://flagcdn.com/24x18/cn.png" alt="ZH-CN"> 简体中文</a> · <a href="README.zh-TW.md"><img src="https://flagcdn.com/24x18/tw.png" alt="ZH-TW"> 繁體中文</a>
+
+# AutoDuty
+
+<img align="right" width="150" height="150" src="../logo.png">
+
+AutoDuty (AD) est un plugin Dalamud pour FFXIV qui sert d'outil pour créer et suivre des chemins à travers les donjons et missions. Il est conçu pour permettre le bouclage automatique de contenu instancié avec le Soutien, les Adelphes ou les Escouades.
+
+Le support se trouve dans [ce canal](https://discord.com/channels/1001823907193552978/1236757595738476725) du [serveur Discord Puni.sh](https://discord.gg/punishxiv).
+
+_Code non licencié, qui suit la [loi sur le droit d'auteur par défaut](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#choosing-the-right-license)_
+
+# Chemins de donjon
+
+<img align="right" height="250" src="../Assets/paths.png">
+
+Chaque donjon supporté par AutoDuty possède un chemin préconfiguré qui devrait compléter le donjon sans problème. Si vous rencontrez des soucis, n'hésitez pas à nous contacter sur le [Discord de support](https://discord.gg/punishxiv).
+
+Les chemins passent également sur tous les coffres au trésor et, lorsque configuré, ramassent le butin et en font quelque chose entre les runs ou après la fin de vos runs programmées.
+
+La création de chemins est aussi possible et facile à réaliser dans AutoDuty via l'onglet `Création` en haut. Pour l'état des chemins, consultez le [tableur épinglé](https://discord.com/channels/1001823907193552978/1236757595738476725/1243059104528994334) dans le [canal AutoDuty](https://discord.com/channels/1001823907193552978/1236757595738476725) du [Discord de support](https://discord.gg/punishxiv).
+
+# Montée de niveau automatique
+
+<img align="right" height="250" src="../Assets/leveling.png">
+
+AutoDuty possède une fonctionnalité de montée de niveau qui vous fait parcourir en continu le "bon" donjon pour progresser. Le donjon est généralement déterminé par la qualité du chemin, le support des combats de boss, et évidemment le niveau du donjon.
+
+Avec AutoDuty, vous pouvez monter une classe du niveau 15 au niveau max très rapidement et en totale autonomie, à condition d'avoir l'équipement adéquat et l'option dans la configuration AD pour équiper automatiquement le meilleur équipement.
+
+Ce plugin peut aussi monter le niveau de vos Adelphes de la même manière. Il sélectionne intelligemment les membres et les monte tous au max, en totale autonomie.
+
+# Automatisations
+
+AutoDuty supporte un large éventail d'automatisations et d'intégrations avec d'autres plugins. Voici quelques-unes des possibilités qu'AD offre lors de l'automatisation de contenu instancié :
+
+| Avant les runs | Pendant la run | Entre les runs | Après les runs |
+| -------- | -------- | -------- | -------- |
+| Se rendre à l'auberge, maison ou domaine de CL <br /> Réparation automatique (soi-même ou PNJ) <br /> Exécuter des commandes (ex: scripts SND) <br /> Consommation automatique d'objets | Ramasser les coffres au trésor <br /> Gérer l'état des plugins | Extraction automatique de matéria <br /> Recyclage automatique du butin <br /> Livraison automatique du butin à la CG <br /> Utiliser AutoRetainer <br /> Équiper automatiquement le meilleur équipement | Arrêter la boucle à un niveau <br /> Arrêter quand plus d'XP de repos <br /> Activer le mode multi d'AutoRetainer <br /> Éteindre votre ordinateur |
+
+<hr />
+
+# Installation
+
+Ajoutez `https://puni.sh/api/repository/erdelf` à vos dépôts de plugins puis recherchez `AutoDuty` dans l'installeur de plugins pour installer AutoDuty.
+
+Les paramètres sont accessibles via l'installeur de plugins ou en utilisant la commande `/ad`.
+
+## Plugins requis
+
+Les plugins suivants sont également requis. Faites un clic droit sur le nom du plugin et copiez l'URL pour l'ajouter à vos dépôts en jeu.
+
+- [vnavmesh](https://puni.sh/api/repository/veyn) : Navigation automatique avec points de passage
+- [Wrath Combo](https://github.com/PunishXIV/WrathCombo) ou [Rotation Solver Reborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json) : Exécution automatique de rotations, toutes les classes supportées
+- [Veyn's Boss Mod](https://puni.sh/api/repository/veyn) ou [BossmodReborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json) : Exécution automatique des combats de boss
+
+## Plugins optionnels
+
+Les plugins suivants sont optionnels. Ils s'intègrent bien avec AutoDuty et dans certains cas peuvent être déclenchés par AD lui-même.
+
+- [Gearsetter](https://plugins.carvel.li) : Trouve automatiquement les améliorations d'équipement dans votre inventaire
+- [AutoRetainer](https://love.puni.sh/ment.json) : Gère automatiquement vos servants et sous-marins et les envoie en expédition
+ 
+# Obtenir de l'aide
+
+Si vous trouvez un bug ou pensez avoir un problème avec le plugin, demandez dans [ce canal](https://discord.com/channels/1001823907193552978/1236757595738476725) du [serveur Discord Puni.sh](https://discord.gg/punishxiv). C'est peut-être un problème connu ou les membres pourront vous aider rapidement. De plus, il peut parfois s'agir d'un problème avec l'un des plugins requis. Les utilisateurs sur Discord pourront aider à trier le problème et vous diriger au bon endroit.
+
+La bonne pratique est de ne pas dire "Je suis mort dans ce donjon et je ne sais pas pourquoi." Incluez autant de détails que possible. Quel boss ? Étiez-vous bloqué à un endroit précis ?
+
+Pour le support de Veyn's Boss Mod et vnavmesh, demandez dans [ce canal](https://discord.com/channels/1001823907193552978/1191076246860349450) du [serveur Discord Puni.sh](https://discord.gg/punishxiv),
+ou pour Wrath Combo dans [ce canal](https://discord.com/channels/1001823907193552978/1271175781569003590) du serveur Puni.sh. Pour BossModReborn et 
+Rotation Solver Reborn, demandez sur le [serveur Discord Combat Reborn](https://discord.gg/p54TZMPnC9).
+
+N'hésitez pas à créer des tickets pour vos demandes de fonctionnalités et rapports de bugs.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,0 +1,71 @@
+<a href="../README.md"><img src="https://flagcdn.com/24x18/gb.png" alt="EN"> English</a> · <a href="README.fr.md"><img src="https://flagcdn.com/24x18/fr.png" alt="FR"> Français</a> · <a href="README.ja.md"><img src="https://flagcdn.com/24x18/jp.png" alt="JA"> 日本語</a> · <a href="README.zh-CN.md"><img src="https://flagcdn.com/24x18/cn.png" alt="ZH-CN"> 简体中文</a> · <a href="README.zh-TW.md"><img src="https://flagcdn.com/24x18/tw.png" alt="ZH-TW"> 繁體中文</a>
+
+# AutoDuty
+
+<img align="right" width="150" height="150" src="../logo.png">
+
+AutoDuty（AD）は、FFXIV用のDalamudプラグインで、ダンジョンやコンテンツのパスを作成・追跡するツールです。フェイス、小隊、またはコンテンツサポーターを使用して、インスタンスコンテンツの自動周回を可能にします。
+
+サポートは [Puni.sh Discordサーバー](https://discord.gg/punishxiv) の [このチャンネル](https://discord.com/channels/1001823907193552978/1236757595738476725) で受けられます。
+
+_ライセンスなしのコード、[デフォルトの著作権法](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#choosing-the-right-license)に従います_
+
+# ダンジョンパス
+
+<img align="right" height="250" src="../Assets/paths.png">
+
+AutoDutyがサポートする各ダンジョンには、問題なくクリアできるパスが事前に設定されています。問題が発生した場合は、[サポートDiscord](https://discord.gg/punishxiv)でお問い合わせください。
+
+パスはすべての宝箱を通過し、設定に応じて戦利品を拾い、周回の合間やすべての周回終了後に処理します。
+
+パスの作成もサポートされており、上部の `Build` タブで簡単に作成できます。パスの状態については、[サポートDiscord](https://discord.gg/punishxiv) の [AutoDutyチャンネル](https://discord.com/channels/1001823907193552978/1236757595738476725) にある [固定スプレッドシート](https://discord.com/channels/1001823907193552978/1236757595738476725/1243059104528994334) を参照してください。
+
+# 自動レベリング
+
+<img align="right" height="250" src="../Assets/leveling.png">
+
+AutoDutyにはレベリング機能があり、適切なダンジョンを継続的に周回してレベルを上げます。ダンジョンはパスの品質、ボス戦のサポート、ダンジョンのレベルによって決定されます。
+
+AutoDutyを使えば、適切な装備とAD設定での自動装備があれば、レベル15から最大レベルまで非常に速く、完全放置で上げることができます。
+
+このプラグインはフェイスのレベルも同様に上げることができます。メンバーを自動的に選択し、全員を最大レベルまで放置で上げられます。
+
+# 自動化機能
+
+AutoDutyは幅広い自動化機能と他のプラグインとの連携をサポートしています。以下はADがインスタンスコンテンツの自動化中に提供できる機能の一部です：
+
+| 周回前 | 周回中 | 周回間 | 周回後 |
+| -------- | -------- | -------- | -------- |
+| 宿屋・自宅・FC邸宅に移動 <br /> 自動修理（自己修理またはNPC） <br /> コマンド実行（SNDスクリプトなど） <br /> アイテム自動使用 | 宝箱の回収 <br /> プラグイン状態の管理 | マテリア自動精製 <br /> 戦利品の自動分解 <br /> GCへの自動納品 <br /> AutoRetainer使用 <br /> 最適装備の自動装着 | 指定レベルで停止 <br /> レストXPがなくなったら停止 <br /> AutoRetainerマルチモード起動 <br /> PCをシャットダウン |
+
+<hr />
+
+# インストール
+
+`https://puni.sh/api/repository/erdelf` をプラグインリポジトリに追加し、プラグインインストーラーで `AutoDuty` を検索してインストールしてください。
+
+設定はプラグインインストーラーまたはチャットコマンド `/ad` からアクセスできます。
+
+## 必須プラグイン
+
+以下のプラグインも必要です。プラグイン名を右クリックしてURLをコピーし、ゲーム内のリポジトリに追加してください。
+
+- [vnavmesh](https://puni.sh/api/repository/veyn)：ウェイポイントによる自動ナビゲーション
+- [Wrath Combo](https://github.com/PunishXIV/WrathCombo) または [Rotation Solver Reborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json)：自動ローテーション実行、全ジョブ対応
+- [Veyn's Boss Mod](https://puni.sh/api/repository/veyn) または [BossmodReborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json)：ボス戦の自動実行
+
+## オプションプラグイン
+
+以下のプラグインはオプションです。AutoDutyとの連携が良く、場合によってはADから直接呼び出すことができます。
+
+- [Gearsetter](https://plugins.carvel.li)：インベントリから装備アップグレードを自動検索
+- [AutoRetainer](https://love.puni.sh/ment.json)：リテイナーとサブマリンの自動管理
+
+# ヘルプ
+
+バグを見つけたり問題があると思った場合は、[Puni.sh Discordサーバー](https://discord.gg/punishxiv) の [このチャンネル](https://discord.com/channels/1001823907193552978/1236757595738476725) でお問い合わせください。
+
+Veyn's Boss Modとvnavmeshのサポートは [Puni.sh Discordサーバー](https://discord.gg/punishxiv) の [このチャンネル](https://discord.com/channels/1001823907193552978/1191076246860349450) で、
+Wrath Comboのサポートは [このチャンネル](https://discord.com/channels/1001823907193552978/1271175781569003590) で受けられます。BossModRebornとRotation Solver Rebornについては [Combat Reborn Discordサーバー](https://discord.gg/p54TZMPnC9) でお問い合わせください。
+
+機能リクエストやバグ報告のIssueもお気軽にどうぞ。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,70 @@
+<a href="../README.md"><img src="https://flagcdn.com/24x18/gb.png" alt="EN"> English</a> · <a href="README.fr.md"><img src="https://flagcdn.com/24x18/fr.png" alt="FR"> Français</a> · <a href="README.ja.md"><img src="https://flagcdn.com/24x18/jp.png" alt="JA"> 日本語</a> · <a href="README.zh-CN.md"><img src="https://flagcdn.com/24x18/cn.png" alt="ZH-CN"> 简体中文</a> · <a href="README.zh-TW.md"><img src="https://flagcdn.com/24x18/tw.png" alt="ZH-TW"> 繁體中文</a>
+
+# AutoDuty
+
+<img align="right" width="150" height="150" src="../logo.png">
+
+AutoDuty（AD）是一个 FFXIV 的 Dalamud 插件，用于创建和跟踪副本路径。它可以使用副本辅助、信赖或军事小队自动循环运行副本内容。
+
+支持频道位于 [Puni.sh Discord 服务器](https://discord.gg/punishxiv) 的 [此频道](https://discord.com/channels/1001823907193552978/1236757595738476725)。
+
+_未授权代码，遵循[默认版权法](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#choosing-the-right-license)_
+
+# 副本路径
+
+<img align="right" height="250" src="../Assets/paths.png">
+
+AutoDuty 支持的每个副本都有预配置的路径，可以顺利完成副本。如遇问题，请在 [支持 Discord](https://discord.gg/punishxiv) 中反馈。
+
+路径会经过所有宝箱，配置后会拾取战利品并在循环之间或所有循环结束后进行处理。
+
+也支持创建路径，可在顶部的 `Build` 选项卡中轻松完成。有关路径状态，请参阅 [支持 Discord](https://discord.gg/punishxiv) 的 [AutoDuty 频道](https://discord.com/channels/1001823907193552978/1236757595738476725) 中的 [置顶表格](https://discord.com/channels/1001823907193552978/1236757595738476725/1243059104528994334)。
+
+# 自动练级
+
+<img align="right" height="250" src="../Assets/leveling.png">
+
+AutoDuty 具有练级功能，会持续运行"合适的"副本来升级。副本通常由路径质量、Boss 战支持和副本等级决定。
+
+使用 AutoDuty，只要拥有合适的装备并在 AD 配置中启用自动装备最佳装备选项，就可以从 15 级快速全自动升到满级。
+
+此插件还可以用同样的方式为信赖成员升级。它可以智能选择成员并将他们全部升到满级，完全自动。
+
+# 自动化功能
+
+AutoDuty 支持广泛的自动化功能和与其他插件的集成。以下是 AD 在自动化副本内容时可以提供的部分功能：
+
+| 循环前 | 副本中 | 循环间 | 循环后 |
+| -------- | -------- | -------- | -------- |
+| 前往旅馆、住宅或部队房屋 <br /> 自动修理（自己或NPC） <br /> 执行命令（如 SND 脚本） <br /> 自动使用消耗品 | 拾取宝箱 <br /> 管理插件状态 | 自动精制魔晶石 <br /> 自动分解战利品 <br /> 自动军票上缴 <br /> 使用 AutoRetainer <br /> 自动装备最佳装备 | 达到指定等级时停止 <br /> 精力奖励用完时停止 <br /> 启动 AutoRetainer 多号模式 <br /> 关闭电脑 |
+
+<hr />
+
+# 安装
+
+将 `https://puni.sh/api/repository/erdelf` 添加到插件仓库，然后在插件安装器中搜索 `AutoDuty` 进行安装。
+
+可通过插件安装器或使用聊天命令 `/ad` 访问设置。
+
+## 必需插件
+
+以下插件也是必需的。右键点击插件名称并复制 URL，添加到游戏内的仓库中。
+
+- [vnavmesh](https://puni.sh/api/repository/veyn)：带路径点的自动导航
+- [Wrath Combo](https://github.com/PunishXIV/WrathCombo) 或 [Rotation Solver Reborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json)：自动循环执行，支持所有职业
+- [Veyn's Boss Mod](https://puni.sh/api/repository/veyn) 或 [BossmodReborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json)：Boss 战自动执行
+
+## 可选插件
+
+以下插件为可选。它们与 AutoDuty 集成良好，某些情况下可由 AD 直接触发。
+
+- [Gearsetter](https://plugins.carvel.li)：自动查找背包中的装备升级
+- [AutoRetainer](https://love.puni.sh/ment.json)：自动管理雇员和潜水艇
+
+# 获取帮助
+
+如果发现 Bug 或遇到问题，请在 [Puni.sh Discord 服务器](https://discord.gg/punishxiv) 的 [此频道](https://discord.com/channels/1001823907193552978/1236757595738476725) 中提问。
+
+Veyn's Boss Mod 和 vnavmesh 的支持请在 [此频道](https://discord.com/channels/1001823907193552978/1191076246860349450)，Wrath Combo 的支持请在 [此频道](https://discord.com/channels/1001823907193552978/1271175781569003590)。BossModReborn 和 Rotation Solver Reborn 请在 [Combat Reborn Discord 服务器](https://discord.gg/p54TZMPnC9) 中提问。
+
+欢迎创建 Issue 提交功能请求和 Bug 报告。

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -1,0 +1,70 @@
+<a href="../README.md"><img src="https://flagcdn.com/24x18/gb.png" alt="EN"> English</a> · <a href="README.fr.md"><img src="https://flagcdn.com/24x18/fr.png" alt="FR"> Français</a> · <a href="README.ja.md"><img src="https://flagcdn.com/24x18/jp.png" alt="JA"> 日本語</a> · <a href="README.zh-CN.md"><img src="https://flagcdn.com/24x18/cn.png" alt="ZH-CN"> 简体中文</a> · <a href="README.zh-TW.md"><img src="https://flagcdn.com/24x18/tw.png" alt="ZH-TW"> 繁體中文</a>
+
+# AutoDuty
+
+<img align="right" width="150" height="150" src="../logo.png">
+
+AutoDuty（AD）是一個 FFXIV 的 Dalamud 插件，用於建立和追蹤副本路徑。它可以使用副本支援、信賴或軍事小隊自動循環運行副本內容。
+
+支援頻道位於 [Puni.sh Discord 伺服器](https://discord.gg/punishxiv) 的 [此頻道](https://discord.com/channels/1001823907193552978/1236757595738476725)。
+
+_未授權代碼，遵循[預設著作權法](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#choosing-the-right-license)_
+
+# 副本路徑
+
+<img align="right" height="250" src="../Assets/paths.png">
+
+AutoDuty 支援的每個副本都有預設路徑，可以順利完成副本。如遇問題，請在 [支援 Discord](https://discord.gg/punishxiv) 中回報。
+
+路徑會經過所有寶箱，設定後會拾取戰利品並在循環之間或所有循環結束後進行處理。
+
+也支援建立路徑，可在頂部的 `Build` 分頁中輕鬆完成。有關路徑狀態，請參閱 [支援 Discord](https://discord.gg/punishxiv) 的 [AutoDuty 頻道](https://discord.com/channels/1001823907193552978/1236757595738476725) 中的 [置頂表格](https://discord.com/channels/1001823907193552978/1236757595738476725/1243059104528994334)。
+
+# 自動練等
+
+<img align="right" height="250" src="../Assets/leveling.png">
+
+AutoDuty 具有練等功能，會持續運行「合適的」副本來升級。副本通常由路徑品質、Boss 戰支援和副本等級決定。
+
+使用 AutoDuty，只要擁有合適的裝備並在 AD 設定中啟用自動裝備最佳裝備選項，就可以從 15 等快速全自動升到滿等。
+
+此插件還可以用同樣的方式為信賴成員升級。它可以智慧選擇成員並將他們全部升到滿等，完全自動。
+
+# 自動化功能
+
+AutoDuty 支援廣泛的自動化功能和與其他插件的整合。以下是 AD 在自動化副本內容時可以提供的部分功能：
+
+| 循環前 | 副本中 | 循環間 | 循環後 |
+| -------- | -------- | -------- | -------- |
+| 前往旅館、住宅或部隊房屋 <br /> 自動修理（自己或NPC） <br /> 執行指令（如 SND 腳本） <br /> 自動使用消耗品 | 拾取寶箱 <br /> 管理插件狀態 | 自動精煉魔晶石 <br /> 自動分解戰利品 <br /> 自動軍票繳交 <br /> 使用 AutoRetainer <br /> 自動裝備最佳裝備 | 達到指定等級時停止 <br /> 精力獎勵用完時停止 <br /> 啟動 AutoRetainer 多號模式 <br /> 關閉電腦 |
+
+<hr />
+
+# 安裝
+
+將 `https://puni.sh/api/repository/erdelf` 新增到插件儲存庫，然後在插件安裝器中搜尋 `AutoDuty` 進行安裝。
+
+可透過插件安裝器或使用聊天指令 `/ad` 存取設定。
+
+## 必要插件
+
+以下插件也是必要的。右鍵點擊插件名稱並複製 URL，新增到遊戲內的儲存庫中。
+
+- [vnavmesh](https://puni.sh/api/repository/veyn)：帶路徑點的自動導航
+- [Wrath Combo](https://github.com/PunishXIV/WrathCombo) 或 [Rotation Solver Reborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json)：自動循環執行，支援所有職業
+- [Veyn's Boss Mod](https://puni.sh/api/repository/veyn) 或 [BossmodReborn](https://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json)：Boss 戰自動執行
+
+## 選用插件
+
+以下插件為選用。它們與 AutoDuty 整合良好，某些情況下可由 AD 直接觸發。
+
+- [Gearsetter](https://plugins.carvel.li)：自動尋找背包中的裝備升級
+- [AutoRetainer](https://love.puni.sh/ment.json)：自動管理僱員和潛水艇
+
+# 取得幫助
+
+如果發現 Bug 或遇到問題，請在 [Puni.sh Discord 伺服器](https://discord.gg/punishxiv) 的 [此頻道](https://discord.com/channels/1001823907193552978/1236757595738476725) 中提問。
+
+Veyn's Boss Mod 和 vnavmesh 的支援請在 [此頻道](https://discord.com/channels/1001823907193552978/1191076246860349450)，Wrath Combo 的支援請在 [此頻道](https://discord.com/channels/1001823907193552978/1271175781569003590)。BossModReborn 和 Rotation Solver Reborn 請在 [Combat Reborn Discord 伺服器](https://discord.gg/p54TZMPnC9) 中提問。
+
+歡迎建立 Issue 提交功能請求和 Bug 回報。


### PR DESCRIPTION
## Summary

- Add multilingual README support with a flag-based language switcher
- Translated READMEs for French, Japanese, Simplified Chinese, and Traditional Chinese
- Translated READMEs are stored in `docs/` to keep the root clean
- Uses small flag images from flagcdn.com for cross-platform compatibility

## Files

- `README.md` -- added language switcher banner at the top
- `docs/README.fr.md` -- French translation
- `docs/README.ja.md` -- Japanese translation
- `docs/README.zh-CN.md` -- Simplified Chinese translation
- `docs/README.zh-TW.md` -- Traditional Chinese translation
