### PR TITLE
Feat: [Duty Support] Add Path for Normal Worqor Lar Dor 

### DIFF
--- a/AutoDuty/Paths/(1195) Worqor Lar Dor.json
+++ b/AutoDuty/Paths/(1195) Worqor Lar Dor.json
@@ -2,7 +2,7 @@
   "Actions": [
     {
       "Tag": "None",
-      "Name": "MoveTo",
+      "Name": "Boss",
       "Position": {
         "X": 100.0,
         "Y": 0.0,

--- a/AutoDuty/Paths/(1195) Worqor Lar Dor.json
+++ b/AutoDuty/Paths/(1195) Worqor Lar Dor.json
@@ -1,0 +1,21 @@
+{
+  "Actions": [
+    {
+      "Tag": "None",
+      "Name": "MoveTo",
+      "Position": {
+        "X": 100.0,
+        "Y": 0.0,
+        "Z": 97.0
+      },
+      "Arguments": [],
+      "Conditions": [],
+      "Note": ""
+    }
+  ],
+  "Meta": {
+    "CreatedAt": 300,
+    "Changelog": [],
+    "Notes": []
+  }
+}


### PR DESCRIPTION
VBM has a contributed module that works. This creates a simple path to engage the boss.