### PR TITLE
Update Duty Counter and Sanitise Inputs

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -745,12 +745,16 @@ public sealed class AutoDuty : IDalamudPlugin
 
         if (ContentHelper.DictionaryContent.TryGetValue(Player.Territory.RowId, out Content? content) && content.DutyModes.HasFlag(DutyMode.Regular))
         {
-            if(ConfigurationMain.Instance.dutyCountResetDate < TimeHelper.GetLastDateTimeForHour(8))
+            if(ConfigurationMain.Instance.dutyCountResetDate <= DateTime.UtcNow)
                 ConfigurationMain.Instance.dutyCountSinceReset.Clear();
 
-            if(!ConfigurationMain.Instance.dutyCountSinceReset.TryAdd(Player.CID, 1))
-                ConfigurationMain.Instance.dutyCountSinceReset[Player.CID]++;
-            ConfigurationMain.Instance.dutyCountResetDate = DateTime.UtcNow;
+            if (ConfigurationMain.Instance.dutyCountSinceReset.TryAdd(Player.CID, 0))
+            {
+                ConfigurationMain.Instance.dutyCountResetDate = TimeHelper.GetNextDateTimeForHour(8);
+                Svc.Log.Debug($"[DutyCount] Added {Player.CID} and set date to {TimeHelper.GetNextDateTimeForHour(8)}");
+            }
+
+            ConfigurationMain.Instance.dutyCountSinceReset[Player.CID]++;
         }
     }
 

--- a/AutoDuty/Helpers/TimeHelper.cs
+++ b/AutoDuty/Helpers/TimeHelper.cs
@@ -10,7 +10,7 @@ namespace AutoDuty.Helpers
                 DateTime.UtcNow.Date.AddDays(1).AddHours(hours);
 
         internal static DateTime GetLastDateTimeForHour(int hours) =>
-            DateTime.UtcNow.Hour > hours ?
+            DateTime.UtcNow.Hour >= hours ?
                 DateTime.UtcNow.Date.AddHours(hours) :
                 DateTime.UtcNow.Date.AddDays(-1).AddHours(hours);
     }

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -500,13 +500,13 @@ namespace AutoDuty.Windows
                     {
                         if (EzThrottler.Throttle("MainTabRemainingDungeonThrottle", 2000))
                         {
-                            if (ConfigurationMain.Instance.dutyCountResetDate < TimeHelper.GetLastDateTimeForHour(8))
+                            if (ConfigurationMain.Instance.dutyCountResetDate <= DateTime.UtcNow)
                                 ConfigurationMain.Instance.dutyCountSinceReset.Clear();
                         }
 
 
                         ImGui.SameLine();
-                        ImGui.Text($"|{Loc.Get("MainTab.DungeonsRemaining", 100 - ConfigurationMain.Instance.dutyCountSinceReset.GetValueOrDefault(Player.CID, 0))}");
+                        ImGui.Text($"|{Loc.Get("MainTab.DungeonsRemaining", Math.Max(0, 100 - ConfigurationMain.Instance.dutyCountSinceReset.GetValueOrDefault(Player.CID, 0)))}");
                         ImGuiComponents.HelpMarker(Loc.Get("MainTab.DungeonsRemainingExplanation"));
                     }
 

--- a/AutoDuty/Windows/MainWindow.cs
+++ b/AutoDuty/Windows/MainWindow.cs
@@ -73,6 +73,9 @@ public sealed class MainWindow : Window, IDisposable
         if ((AutoDuty.Configuration.UseSliderInputs  && ImGui.SliderInt("Times", ref AutoDuty.Configuration.LoopTimes, 0, 100)) || 
             (!AutoDuty.Configuration.UseSliderInputs && ImGui.InputInt("Times", ref AutoDuty.Configuration.LoopTimes, 1)))
         {
+            if (AutoDuty.Configuration.LoopTimes < 0) AutoDuty.Configuration.LoopTimes = 0;
+            if (AutoDuty.Configuration.LoopTimes > 100) AutoDuty.Configuration.LoopTimes = 100;
+
             if (AutoDuty.Configuration.AutoDutyModeEnum == AutoDutyMode.Playlist)
                 Plugin.PlaylistCurrentEntry?.count = AutoDuty.Configuration.LoopTimes;
 


### PR DESCRIPTION
Updates the dungeon remaining counter to reset correctly after the reset time.

Prevent input int for duty count from going above 100 or below 0.