### PR TITLE
Add Japanese positional labels

### DIFF
--- a/AutoDuty/Localization/ja-JP/ConfigTab.json
+++ b/AutoDuty/Localization/ja-JP/ConfigTab.json
@@ -244,6 +244,12 @@
       "ResynchronizeStep": "ステップ再同期"
     },
     "Enums": {
+      "Positional": {
+        "Any": "指定なし",
+        "Flank": "側面",
+        "Rear": "背面",
+        "Front": "正面"
+      },
       "RetireLocation": {
         "Inn": "宿屋",
         "Apartment": "アパルトメント",


### PR DESCRIPTION
## Summary

- Add ja-JP labels for the `Any`, `Flank`, `Rear`, and `Front` positional options.
- Replace the English fallback labels with concise Japanese terms appropriate for the in-game context.

## Why

PR #383 added localization support and en-US keys for the positional selector, but the corresponding ja-JP keys were still missing. As a result, the selector continued to display English labels when using ja-JP.

## Validation

- Built `AutoDuty.csproj` in Debug/x64 successfully (0 errors).
- Verified en-US continues to display `Any`, `Flank`, `Rear`, and `Front`.
- Verified ja-JP displays `指定なし`, `側面`, `背面`, and `正面`.
- Switched between en-US and ja-JP and confirmed the selected value remains unchanged and displays correctly in both languages.
