### PR TITLE
Improve Japanese command, inventory, and Armoire labels

### DIFF
--- a/AutoDuty/Localization/ja-JP/ConfigTab.json
+++ b/AutoDuty/Localization/ja-JP/ConfigTab.json
@@ -102,7 +102,8 @@
     "PreLoop": {
       "Header": "ループ前初期化設定",
       "Enable": "有効",
-      "ExecuteCommands": "全ループ開始時にコマンド実行",
+      "ExecuteCommands": "ループ処理開始前にコマンドを実行",
+      "ExecuteCommandsHelp": "一連のループ処理を開始する前に、登録したコマンドを実行します。\n例：{0}",
       "BetweenLoopNote": "ループ間設定が有効な場合、以下はループ間にも実行されます（現在 {0}）",
       "RetireTo": "退避先 ",
       "AddCurrentPosition": "現在位置を追加",
@@ -137,7 +138,8 @@
       "RunOnLastLoop": "最終ループでも実行",
       "WaitTime": "(秒) ループ間の待機時間",
       "WaitTimeHelp": "ループ間処理をX秒遅延させます。",
-      "ExecuteCommands": "全ループ間でコマンド実行",
+      "ExecuteCommands": "ループ間にコマンドを実行",
+      "ExecuteCommandsHelp": "ループ間処理の実行時に、登録したコマンドを実行します。\n例：{0}",
       "AutoExtract": "マテリア自動精製",
       "Equipped": "装備中",
       "All": "すべて",
@@ -200,7 +202,8 @@
       "StopOnlyWhenAllSpells": "全魔法習得時のみ停止",
       "StopWhenInventoryFull": "所持品がいっぱいになったら停止",
 
-      "ExecuteCommandsOnTermination": "全ループ終了時にコマンド実行",
+      "ExecuteCommandsOnTermination": "ループ処理終了時にコマンドを実行",
+      "ExecuteCommandsOnTerminationHelp": "一連のループ処理が終了したときに、登録したコマンドを実行します。\n例：{0}",
       "PlaySoundOnCompletion": "全ループ完了時に音を鳴らす: ",
       "OnCompletionOfAllLoops": "全ループ完了時: ",
       "KeepTerminationActive": "実行後も終了オプションを維持 "

--- a/AutoDuty/Localization/ja-JP/ConfigTab.json
+++ b/AutoDuty/Localization/ja-JP/ConfigTab.json
@@ -200,7 +200,8 @@
       "StopBLUSpell": "青魔法習得時に停止",
       "SelectBLUSpell": "青魔法を選択",
       "StopOnlyWhenAllSpells": "全魔法習得時のみ停止",
-      "StopWhenInventoryFull": "所持品がいっぱいになったら停止",
+      "StopWhenInventoryFull": "所持品の空き枠が少なくなったら停止",
+      "StopWhenInventoryFullSlots": "停止する空き枠数：",
 
       "ExecuteCommandsOnTermination": "ループ処理終了時にコマンドを実行",
       "ExecuteCommandsOnTerminationHelp": "一連のループ処理が終了したときに、登録したコマンドを実行します。\n例：{0}",

--- a/AutoDuty/Localization/ja-JP/Overlay.json
+++ b/AutoDuty/Localization/ja-JP/Overlay.json
@@ -8,7 +8,8 @@
       "Repair": "修理",
       "Equip": "装備更新",
       "Coffers": "装備箱",
-      "TripleTriad": "トリプルトライアド"
+      "TripleTriad": "トリプルトライアド",
+      "Armoire": "愛蔵品"
     },
     "Tooltip": {
       "TurnIn": "クリックでグランドカンパニー納品場所へ移動し、AutoRetainerのGC納品を実行します",

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -2812,7 +2812,7 @@ public static class ConfigTab
 
         static void MakeCommands(string checkbox, ref bool execute, ref List<string> commands, ref string curCommand, string id)
         {
-            if (ImGui.Checkbox(Loc.Get(checkbox), ref execute))
+            if (ImGui.Checkbox($"{Loc.Get(checkbox)}{(execute ? ":" : string.Empty)} ", ref execute))
                 Configuration.Save();
 
             ImGuiComponents.HelpMarker(Loc.Get(checkbox + "Help", "/echo test"));

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -2812,7 +2812,7 @@ public static class ConfigTab
 
         static void MakeCommands(string checkbox, ref bool execute, ref List<string> commands, ref string curCommand, string id)
         {
-            if (ImGui.Checkbox($"{Loc.Get(checkbox)}{(execute ? ":" : string.Empty)} ", ref execute))
+            if (ImGui.Checkbox(Loc.Get(checkbox), ref execute))
                 Configuration.Save();
 
             ImGuiComponents.HelpMarker(Loc.Get(checkbox + "Help", "/echo test"));


### PR DESCRIPTION
## Summary

- Add ja-JP help text for the pre-loop, between-loop, and loop-termination command settings.
- Revise the corresponding ja-JP checkbox labels to use consistent terminology for the loop lifecycle.
- Revise the inventory termination label and add the missing free-slot threshold label.
- Add the missing ja-JP label for `Overlay.Button.Armoire`.

## Why

The three command help-text keys were missing from ja-JP, so their English text was displayed as a fallback. The existing Japanese checkbox labels also used inconsistent and potentially ambiguous wording.

`ConfigTab.Termination.StopWhenInventoryFullSlots` was missing from ja-JP, causing an English fallback and repeated missing-localization warnings. The existing Japanese parent label described stopping only when the inventory was full, although the feature stops when the configured number of free slots is reached. The revised pair describes that threshold behavior more accurately.

`Overlay.Button.Armoire` was also missing from ja-JP, causing the English label and repeated missing-localization warnings. `愛蔵品` fits the compact action button while clearly identifying its function.

## Validation

- Built `AutoDuty.csproj` in Debug/x64 successfully (0 errors).
- Verified all three updated command labels and help texts in ja-JP.
- Verified all three command settings remain in English when using en-US.
- Switched between ja-JP and en-US and confirmed the command labels display correctly and each setting remains selected.
- Verified the inventory termination labels display correctly in ja-JP and remain in English in en-US.
- Switched between ja-JP and en-US and confirmed no display issues with the inventory termination setting.
- Verified the missing-localization warning for `StopWhenInventoryFullSlots` no longer appears.
- Verified the overlay displays `愛蔵品` in ja-JP.
- Verified the repeated missing-localization warnings for the Armoire button no longer appear.

## Scope

The command input hint and the `Add Command` button are still hardcoded in English. They are outside the scope of this localization-focused PR.
