### PR TITLE
add temp config overrides

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -2296,6 +2296,8 @@ public sealed class AutoDuty : IDalamudPlugin
 
     private void StopAndResetAll()
     {
+        ConfigOverrideHelper.Pop();
+
         if (this.bareModeSettingsActive != SettingsActive.None)
         {
             Configuration.EnablePreLoopActions     = this.bareModeSettingsActive.HasFlag(SettingsActive.PreLoop_Enabled);

--- a/AutoDuty/Helpers/ConfigHelper.cs
+++ b/AutoDuty/Helpers/ConfigHelper.cs
@@ -31,7 +31,7 @@ namespace AutoDuty.Helpers
             }
         }
 
-        private static object? ModifyConfig(Type configType, string configValue, out string failReason)
+        internal static object? ConvertConfigValue(Type configType, string configValue, out string failReason)
         {
             failReason = $"value must be of type: {configType.ToString().Replace("System.", "")}";
 
@@ -45,7 +45,7 @@ namespace AutoDuty.Helpers
                     return configEnum;
             } else if (configType is { IsGenericType: true, IsGenericTypeDefinition: false } && configType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
-                return Activator.CreateInstance(configType, ModifyConfig(configType.GetGenericArguments()[0], configValue, out failReason));
+                return Activator.CreateInstance(configType, ConvertConfigValue(configType.GetGenericArguments()[0], configValue, out failReason));
             }
             else if (configType.GetInterface(nameof(IConvertible)) != null)
             {
@@ -55,6 +55,9 @@ namespace AutoDuty.Helpers
 
             return null;
         }
+
+        private static object? ModifyConfig(Type configType, string configValue, out string failReason) =>
+            ConvertConfigValue(configType, configValue, out failReason);
 
         internal static bool ModifyConfig(string configName, params string[] configValues)
         {

--- a/AutoDuty/Helpers/ConfigOverrideHelper.cs
+++ b/AutoDuty/Helpers/ConfigOverrideHelper.cs
@@ -1,0 +1,91 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using ECommons.DalamudServices;
+
+namespace AutoDuty.Helpers;
+
+internal static class ConfigOverrideHelper
+{
+    private readonly record struct OverrideEntry(FieldInfo Field, object? PreviousValue);
+    private static readonly Dictionary<FieldInfo, OverrideEntry> Active = [];
+
+    internal static bool HasOverrides => Active.Count > 0;
+
+    internal static bool Push(Dictionary<string, string> overrides)
+    {
+        if (overrides is null || overrides.Count == 0)
+        {
+            Svc.Log.Error("Overrides dictionary empty");
+            return false;
+        }
+
+        List<FieldInfo> newlyTracked = [];
+        List<(FieldInfo Field, object? Before)> touched = [];
+        foreach ((string name, string value) in overrides)
+        {
+            FieldInfo? field = ConfigHelper.FindConfig(name);
+            if (field is null)
+            {
+                Svc.Log.Error($"Unable to find config: {name}");
+                Revert(touched, newlyTracked);
+                return false;
+            }
+
+            if (field.FieldType.ToString().Contains("Dalamud.Plugin", System.StringComparison.InvariantCultureIgnoreCase))
+            {
+                Svc.Log.Error($"Cannot override plugin field: {name}");
+                Revert(touched, newlyTracked);
+                return false;
+            }
+
+            if (field.FieldType.IsAssignableTo(typeof(IList)))
+            {
+                Svc.Log.Error($"List configs are not supported: {name}");
+                Revert(touched, newlyTracked);
+                return false;
+            }
+
+            object? newValue = ConfigHelper.ConvertConfigValue(field.FieldType, value, out string failReason);
+            if (newValue is null)
+            {
+                Svc.Log.Error($"Unable to set {name}: {failReason}");
+                Revert(touched, newlyTracked);
+                return false;
+            }
+
+            object? before = field.GetValue(Configuration);
+            touched.Add((field, before));
+            if (!Active.ContainsKey(field))
+            {
+                Active[field] = new OverrideEntry(field, before);
+                newlyTracked.Add(field);
+            }
+
+            field.SetValue(Configuration, newValue);
+        }
+
+        Svc.Log.Debug($"Applied {overrides.Count} override(s); active={Active.Count}");
+        return true;
+    }
+
+    internal static bool Pop()
+    {
+        if (Active.Count == 0)
+            return false;
+
+        Svc.Log.Debug($"Restoring {Active.Count} override(s)");
+        foreach (OverrideEntry entry in Active.Values)
+            entry.Field.SetValue(Configuration, entry.PreviousValue);
+        Active.Clear();
+        return true;
+    }
+
+    private static void Revert(List<(FieldInfo Field, object? Before)> touched, List<FieldInfo> newlyTracked)
+    {
+        for (int i = touched.Count - 1; i >= 0; i--)
+            touched[i].Field.SetValue(Configuration, touched[i].Before);
+        foreach (FieldInfo field in newlyTracked)
+            Active.Remove(field);
+    }
+}

--- a/AutoDuty/IPC/IPCProvider.cs
+++ b/AutoDuty/IPC/IPCProvider.cs
@@ -7,6 +7,7 @@ using ECommons.EzIpcManager;
 
 namespace AutoDuty.IPC
 {
+    using System.Collections.Generic;
     using ECommons.DalamudServices;
     using Newtonsoft.Json.Linq;
 
@@ -39,6 +40,25 @@ namespace AutoDuty.IPC
                     break;
             }
         }
+
+        [EzIPC]
+        public bool PushConfigOverrides(object overrides)
+        {
+            Dictionary<string, string> dict = overrides switch
+            {
+                Dictionary<string, string> d => d,
+                JObject jo => jo.ToObject<Dictionary<string, string>>() ?? [],
+                _ => null
+            };
+            if (dict is null)
+            {
+                Svc.Log.Warning("Expected Dictionary<string, string>");
+                return false;
+            }
+            return ConfigOverrideHelper.Push(dict);
+        }
+
+        [EzIPC] public bool PopConfigOverrides() => ConfigOverrideHelper.Pop(); // don't really need to ever call this since AD does already on stop
 
         [EzIPC] public void Run(uint   territoryType, int loops = 0, bool bareMode = false)
         {

--- a/AutoDuty/Localization/en-US/ConfigTab.json
+++ b/AutoDuty/Localization/en-US/ConfigTab.json
@@ -11,6 +11,7 @@
       "Delete": "Delete Config",
       "DeleteHelp": "Delete Config\nHold ctrl to enable",
       "BareProfileNote": "The bare profile is for just running a duty, and nothing else. You can duplicate it to make edits.",
+      "ConfigOverridesActiveNote": "Config is locked while IPC config overrides are active. Stop AutoDuty to edit again.",
       "NewProfileName": "New Profile Name",
       "ChangeProfileName": "Change Profile Name"
     },

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -779,12 +779,15 @@ public class Configuration
     public string                                      SoundPath                    = "";
     public TerminationMode                             TerminationMethodEnum        = TerminationMode.Do_Nothing;
     public bool                                        TerminationKeepActive        = true;
-    #endregion
+	#endregion
 
-    public static void Save() => 
-        EzConfig.Save();
+	public static void Save()
+	{
+        if (!ConfigOverrideHelper.HasOverrides)
+		    EzConfig.Save();
+	}
 
-    public TrustMemberName?[] SelectedTrustMembers = new TrustMemberName?[3];
+	public TrustMemberName?[] SelectedTrustMembers = new TrustMemberName?[3];
 }
 
 public static class ConfigTab

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -881,6 +881,11 @@ public static class ConfigTab
 
         ImGui.Separator();
 
+        bool overridesActive = ConfigOverrideHelper.HasOverrides;
+        if (overridesActive)
+            ImGuiEx.TextWrapped(Loc.Get("ConfigTab.Profile.ConfigOverridesActiveNote"));
+        using ImRaii.DisabledDisposable overrideLock = ImRaii.Disabled(overridesActive);
+
         //Start of Profile Selection
         ImGui.AlignTextToFramePadding();
         ImGui.Text(Loc.Get("ConfigTab.Profile.CurrentlySelected"));


### PR DESCRIPTION
adds a push/pop system to ipc for config overriding.
then one can push a dict of values and AD will use it without saving and pops it when AD stops for any reason