### PR TITLE
Protect Gearsetter-recommended gear from Auto Desynth

### DIFF
--- a/AutoDuty/Helpers/DesynthHelper.cs
+++ b/AutoDuty/Helpers/DesynthHelper.cs
@@ -6,6 +6,7 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using AutoDuty.IPC;
 
 namespace AutoDuty.Helpers
 {
@@ -28,11 +29,55 @@ namespace AutoDuty.Helpers
         internal override void Start()
         {
             this._maxDesynthLevel = PlayerHelper.GetMaxDesynthLevel();
+            this._gearsetterProtectedSlots = this.BuildGearsetterProtectedSlots();
             if(this.NextCategory(true))
                 base.Start();
         }
 
         private float _maxDesynthLevel = 1;
+
+        private HashSet<(InventoryType InventoryType, int Slot)> _gearsetterProtectedSlots = [];
+
+        private unsafe HashSet<(InventoryType, int)> BuildGearsetterProtectedSlots()
+        {
+            HashSet<(InventoryType, int)> protectedSlots = [];
+
+            if (!Configuration.AutoDesynthProtectGearsetterUpgrades || !Gearsetter_IPCSubscriber.IsEnabled)
+                return protectedSlots;
+
+            try
+            {
+                RaptureGearsetModule* gearsetModule = RaptureGearsetModule.Instance();
+
+                for (int gearsetId = 0; gearsetId < gearsetModule->NumGearsets; gearsetId++)
+                {
+                    if (!gearsetModule->GetGearset(gearsetId)->Flags.HasFlag(RaptureGearsetModule.GearsetFlag.Exists))
+                        continue;
+
+                    List<(uint ItemId, InventoryType? SourceInventory, byte? SourceInventorySlot, RaptureGearsetModule.GearsetItemIndex TargetSlot)>? recommendations =
+                        Gearsetter_IPCSubscriber.GetRecommendationsForGearset((byte)gearsetId);
+
+                    if (recommendations == null)
+                        continue;
+
+                    foreach ((uint recItemId, InventoryType? sourceInventory, byte? sourceInventorySlot, _) in recommendations)
+                    {
+                        if (sourceInventory == null || sourceInventorySlot == null)
+                            continue;
+
+                        if (protectedSlots.Add((sourceInventory.Value, sourceInventorySlot.Value)))
+                            this.DebugLog($"Gearsetter protects item {recItemId} in {sourceInventory} slot {sourceInventorySlot} (recommended for gearset {gearsetId}) from Auto Desynth");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Svc.Log.Warning($"[AutoDesynth] Gearsetter IPC call failed while collecting upgrade protection, falling back to gearset-only protection for this run: {ex.Message}");
+                protectedSlots.Clear();
+            }
+
+            return protectedSlots;
+        }
 
         private AgentSalvage.SalvageItemCategory curCategory;
 
@@ -134,6 +179,12 @@ namespace AutoDuty.Helpers
 
                                 if (gearsetItemIds.Contains(inventoryItem->GetItemId()))
                                     continue;
+                            }
+
+                            if (this._gearsetterProtectedSlots.Contains((item.InventoryType, (int)item.InventorySlot)))
+                            {
+                                this.DebugLog($"Skipping Item({i}): {itemSheetRow.Value.Name} - protected by Gearsetter as an upgrade for another gearset");
+                                continue;
                             }
 
                             this.DebugLog($"Salvaging Item({i}): {itemSheetRow.Value.Name} {inventoryItem->ItemId} {inventoryItem->GetItemId()} {inventoryItem->GetBaseItemId()} with iLvl {itemLevel} because our desynth level is {desynthLevel}");

--- a/AutoDuty/Localization/en-US/ConfigTab.json
+++ b/AutoDuty/Localization/en-US/ConfigTab.json
@@ -163,6 +163,8 @@
       "ItemLevelLimit": "Item Level Limit",
       "ItemLevelLimitHelp": "Stops desynthesising an item once your desynthesis skill reaches the Item Level + this limit.",
       "ProtectGearsets": "Protect Gearsets",
+      "ProtectGearsetterUpgrades": "Protect Gearsetter upgrades from Auto Desynth",
+      "ProtectGearsetterUpgradesHelp": "Also protects items that Gearsetter recommends as an upgrade for any of your gearsets, even if they aren't equipped in one yet. Requires the Gearsetter plugin.",
       "DesynthCategories": "Desynth Categories",
       "AutoGCTurnin": "Auto GC Turnin",
       "InventorySlotsLeft": "Inventory Slots Left @",

--- a/AutoDuty/Localization/ko-KR/ConfigTab.json
+++ b/AutoDuty/Localization/ko-KR/ConfigTab.json
@@ -162,6 +162,8 @@
       "ItemLevelLimit": "아이템 레벨 상한",
       "ItemLevelLimitHelp": "분해 스킬이 '아이템 레벨 + 이 값'에 도달하면 해당 아이템의 분해를 중단합니다.",
       "ProtectGearsets": "장비세트 보호",
+      "ProtectGearsetterUpgrades": "Gearsetter 업그레이드 장비 자동 분해 방지",
+      "ProtectGearsetterUpgradesHelp": "아직 어떤 장비세트에도 등록되지 않았더라도, Gearsetter가 업그레이드로 추천하는 장비는 분해하지 않고 보호합니다. Gearsetter 플러그인이 필요합니다.",
       "DesynthCategories": "분해 카테고리",
       "AutoGCTurnin": "총사령부 납품 자동화",
       "InventorySlotsLeft": "소지품 빈 칸이 @ 이하일 때",

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -744,10 +744,11 @@ public class Configuration
                 this.AutoDesynth = false;
         }
     }
-    public int   AutoDesynthSkillUpLimit = 50;
-    public bool  AutoDesynthNQOnly       = false;
-    public bool  AutoDesynthNoGearset    = true;
-    public ulong AutoDesynthCategories   = 0x1;
+    public int   AutoDesynthSkillUpLimit              = 50;
+    public bool  AutoDesynthNQOnly                    = false;
+    public bool  AutoDesynthNoGearset                 = true;
+    public bool  AutoDesynthProtectGearsetterUpgrades = false;
+    public ulong AutoDesynthCategories                = 0x1;
 
     internal bool autoGCTurnin            = false;
     public bool AutoGCTurnin
@@ -2223,6 +2224,13 @@ public static class ConfigTab
 
                     if (ImGui.Checkbox($"{Loc.Get("ConfigTab.BetweenLoop.ProtectGearsets")}##Desynth{nameof(Configuration.AutoDesynthNoGearset)}", ref Configuration.AutoDesynthNoGearset))
                         Configuration.Save();
+
+                    using (ImGuiHelper.RequiresPlugin(ExternalPlugin.Gearsetter, "DesynthGearsetter", inline: true))
+                    {
+                        if (ImGui.Checkbox($"{Loc.Get("ConfigTab.BetweenLoop.ProtectGearsetterUpgrades")}##Desynth{nameof(Configuration.AutoDesynthProtectGearsetterUpgrades)}", ref Configuration.AutoDesynthProtectGearsetterUpgrades))
+                            Configuration.Save();
+                    }
+                    ImGuiComponents.HelpMarker(Loc.Get("ConfigTab.BetweenLoop.ProtectGearsetterUpgradesHelp"));
 
                     if (ImGui.CollapsingHeader(Loc.Get("ConfigTab.BetweenLoop.DesynthCategories")))
                     {


### PR DESCRIPTION
Adds an option to protect Gearsetter-recommended upgrade gear from Auto Desynth, even before it's equipped in a gear set.

- New option: **Protect Gearsetter upgrades from Auto Desynth** (default false)
- No effect if Gearsetter isn't installed or the option is off
- Tested in-game: recommended items are skipped, everything else desynths normally