### PR TITLE
Add search to Preferred Repair NPC selector

### DIFF
--- a/AutoDuty/Localization/en-US/ConfigTab.json
+++ b/AutoDuty/Localization/en-US/ConfigTab.json
@@ -122,6 +122,7 @@
       "TriggerAt": "Trigger @",
       "PreferredRepairNPC": "Preferred Repair NPC: ",
       "PreferredRepairNPCHelp": "It's a good idea to match the Repair NPC with Summoning Bell and if possible Retire Location",
+      "RepairNPCSearchHint": "Start typing NPC or zone name to search",
       "GrandCompanyInn": "Grand Company Inn",
       "AutoConsume": "Auto Consume",
       "AutoConsumeHelp": "AutoDuty will consume these items on run and between each loop (if status does not exist)",

--- a/AutoDuty/Localization/ko-KR/ConfigTab.json
+++ b/AutoDuty/Localization/ko-KR/ConfigTab.json
@@ -121,6 +121,7 @@
       "TriggerAt": "발동 임계값 @",
       "PreferredRepairNPC": "선호 수리 NPC: ",
       "PreferredRepairNPCHelp": "가능하면 수리 NPC를 소환 벨이나 귀환 위치와 맞추는 것을 권장합니다",
+      "RepairNPCSearchHint": "NPC 이름 또는 지역명을 입력하여 검색",
       "GrandCompanyInn": "그랜드 컴퍼니 막사",
       "AutoConsume": "소비 아이템 자동 사용",
       "AutoConsumeHelp": "실행 중 및 각 반복 작업 간에 대상 상태가 없는 경우 이 아이템들을 사용합니다",

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -859,6 +859,8 @@ public static class ConfigTab
     private static string         consumableItemsItemNameInput = "";
     private static ConsumableItem consumableItemsSelectedItem  = new();
 
+    private static string preferredRepairNPCSearchInput = "";
+
     private static string profileRenameInput = "";
 
     private static readonly Sounds[] validSounds = [..((Sounds[])Enum.GetValues(typeof(Sounds))).Where(s => s is not Sounds.None and not Sounds.Unknown)];
@@ -1907,13 +1909,19 @@ public static class ConfigTab
                                                  $"{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(Configuration.PreferredRepairNPC.Name.ToLowerInvariant())} ({Svc.Data.GetExcelSheet<TerritoryType>()?.GetRowOrDefault(Configuration.PreferredRepairNPC.TerritoryType)?.PlaceName.ValueNullable?.Name.ToString()})  ({MapHelper.ConvertWorldXZToMap(Configuration.PreferredRepairNPC.Position.ToVector2(), Svc.Data.GetExcelSheet<TerritoryType>().GetRow(Configuration.PreferredRepairNPC.TerritoryType).Map.Value!).X.ToString("0.0", CultureInfo.InvariantCulture)}, {MapHelper.ConvertWorldXZToMap(Configuration.PreferredRepairNPC.Position.ToVector2(), Svc.Data.GetExcelSheet<TerritoryType>().GetRow(Configuration.PreferredRepairNPC.TerritoryType).Map.Value).Y.ToString("0.0", CultureInfo.InvariantCulture)})" :
                                                  Loc.Get("ConfigTab.PreLoop.GrandCompanyInn")))
                         {
+                            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                            ImGui.InputTextWithHint("##PreferredRepairSearch", Loc.Get("ConfigTab.PreLoop.RepairNPCSearchHint"), ref preferredRepairNPCSearchInput, 100);
+
                             if (ImGui.Selectable(Loc.Get("ConfigTab.PreLoop.GrandCompanyInn"), Configuration.PreferredRepairNPC == null))
                             {
                                 Configuration.PreferredRepairNPC = null;
                                 Configuration.Save();
                             }
 
-                            foreach (RepairNpcData repairNPC in RepairNPCs)
+                            foreach (RepairNpcData repairNPC in RepairNPCs.Where(x =>
+                                         string.IsNullOrEmpty(preferredRepairNPCSearchInput) ||
+                                         x.Name.Contains(preferredRepairNPCSearchInput, StringComparison.InvariantCultureIgnoreCase) ||
+                                         (Svc.Data.GetExcelSheet<TerritoryType>()?.GetRowOrDefault(x.TerritoryType)?.PlaceName.ValueNullable?.Name.ToString().Contains(preferredRepairNPCSearchInput, StringComparison.InvariantCultureIgnoreCase) ?? false)))
                             {
                                 if (repairNPC.TerritoryType <= 0)
                                 {


### PR DESCRIPTION
Adds a search field to the Preferred Repair NPC selector to make long NPC lists easier to navigate.

- Filters repair NPCs by NPC name or zone name
- Matching is case-insensitive
- Adds localized search hints for en-US and ko-KR
- Keeps the Grand Company Inn option available regardless of the filter