### PR TITLE
Fix AutoDesynthNoGearset incorrectly skipping items

### DIFF
--- a/AutoDuty/Helpers/DesynthHelper.cs
+++ b/AutoDuty/Helpers/DesynthHelper.cs
@@ -119,16 +119,15 @@ namespace AutoDuty.Helpers
                                     gearsetItemIds = [];
 
                                     RaptureGearsetModule* gearsetModule = RaptureGearsetModule.Instance();
-                                    byte                  num           = gearsetModule->NumGearsets;
-                                    for (byte j = 0; j < num; j++)
+                                    for (byte j = 0; j < gearsetModule->Entries.Length; j++)
                                     {
-                                        foreach (RaptureGearsetModule.GearsetEntry entry in gearsetModule->Entries)
-                                            foreach (RaptureGearsetModule.GearsetItem gearsetItem in entry.Items)
-                                            {
-                                                uint gearsetItemItemId = gearsetItem.ItemId;
-                                                if(gearsetItemItemId > 0) 
-                                                    gearsetItemIds.Add(gearsetItemItemId);
-                                            }
+                                        if (!gearsetModule->IsValidGearset(j)) continue;
+
+                                        foreach (RaptureGearsetModule.GearsetItem gearsetItem in gearsetModule->Entries[j].Items) {
+                                            uint gearsetItemItemId = gearsetItem.ItemId;
+                                            if(gearsetItemItemId > 0) 
+                                                gearsetItemIds.Add(gearsetItemItemId);
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
## Summary
- `AutoDesynthNoGearset`'s gearset-item lookup looped `NumGearsets` times but never
  used the loop counter as an index — it just re-scanned the full raw `Entries`
  array each time instead of walking actual gearset entry IDs
- `NumGearsets` is a *count* of existing gearsets, not the highest entry ID in
  use — entry IDs are assigned at creation and never get compacted/reused when
  a gearset is deleted, so a gearset can sit at an entry ID well past
  `NumGearsets`. Looping to `NumGearsets` silently misses those, while the raw
  `Entries` scan (independent of the loop bound) picks up leftover item IDs
  from deleted/invalid slots instead
- Fix: iterate all fixed gearset slots (`Entries.Length`) and use
  `IsValidGearset(j)` to only collect item IDs from gearsets that currently
  exist, regardless of their entry ID

<img width="362" height="622" alt="image" src="https://github.com/user-attachments/assets/77a7abb3-a215-45ee-90d4-fb02bfda27e3" />
